### PR TITLE
Updated PSF FWHM calculation

### DIFF
--- a/astroduet/utils.py
+++ b/astroduet/utils.py
@@ -95,7 +95,7 @@ def get_neff(psf_size, pixel_size):
     >>> from astroduet.config import Telescope
     >>> duet = Telescope()
     >>> neff = get_neff(duet.psf_size, duet.pixel)
-    >>> np.isclose(neff, 3.597839101366366)
+    >>> np.isclose(neff, 3.3581908798935647)
     True
 
     """


### PR DESCRIPTION
...now does a proper radial profile and returns the FWHM. Hard-coded the radial profile into the config.py and updated the unit tests for utils.py for get_neff since that value changed slightly.

update_psf_values() for the Telescope() class now properly renormalizes the Gaussians so that the resulting kernel has a normalization close to 1 and recomputes the psf_fwhm, psf_size, and neff attributes.

