### PR TITLE
Updated requirements.txt and .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,5 +14,6 @@ dist/*
 astroduet/cython_version.py
 astroduet/data/*DUET.fits
 .coverage
-
+notebooks/debug_imgs*
+notebooks/*hdf5
 htmlcov/

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,3 +6,4 @@ photutils
 jupyter
 tqdm
 h5py
+pyyaml


### PR DESCRIPTION
Should now ignore debug-style HDF5 files and debug_imgs in notebooks.

Added pyyaml to requirements.