### PR TITLE
Added 1D background estimation

### DIFF
--- a/notebooks/Test - image backgrounds.ipynb
+++ b/notebooks/Test - image backgrounds.ipynb
@@ -1,0 +1,423 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": 134,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "The autoreload extension is already loaded. To reload it, use:\n",
+      "  %reload_ext autoreload\n"
+     ]
+    }
+   ],
+   "source": [
+    "%load_ext autoreload\n",
+    "%autoreload 2\n",
+    "import numpy as np\n",
+    "import numpy as np\n",
+    "import matplotlib.pyplot as plt\n",
+    "from astropy import units as u\n",
+    "from astroduet.bbmag import bb_abmag_fluence\n",
+    "from astroduet.image_utils import construct_image, find, ap_phot, run_daophot\n",
+    "from astroduet.config import Telescope\n",
+    "from astroduet.background import background_pixel_rate\n",
+    "from astroduet.utils import duet_abmag_to_fluence\n",
+    "from astropy.table import Table\n",
+    "from astropy.io import fits\n",
+    "from astropy.stats import sigma_clipped_stats\n",
+    "from astroduet.diff_image import py_zogy\n",
+    "from astroduet.image_utils import estimate_background"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 127,
+   "metadata": {
+    "scrolled": false
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "-----\n",
+      "Background Computation Integrating over Pixel Area\n",
+      "Telescope diameter: 26.0 cm\n",
+      "Collecting Area: 459.9605804120816 cm2\n",
+      "Transmission Efficiency: 0.8166518036622619\n",
+      "\n",
+      "\n",
+      "Pixel Size: 6.4 arcsec\n",
+      "Pixel Area: 40.96000000000001 arcsec2\n",
+      "\n",
+      "Zodi Level: 77\n",
+      "Band1 Rate: 0.030369732491096913 ph / s\n",
+      "Band2 Rate: 0.2478588509265617 ph / s\n",
+      "-----\n",
+      "7\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "/Users/mheida/software/miniconda2/envs/duet/lib/python3.6/site-packages/scipy/stats/_binned_statistic.py:607: FutureWarning: Using a non-tuple sequence for multidimensional indexing is deprecated; use `arr[tuple(seq)]` instead of `arr[seq]`. In the future this will be interpreted as an array index, `arr[np.array(seq)]`, which will result either in an error or a different result.\n",
+      "  result = result[core]\n"
+     ]
+    }
+   ],
+   "source": [
+    "duet = Telescope()\n",
+    "[bgd_band1, bgd_band2] = background_pixel_rate(duet, low_zodi = True, diag=True)\n",
+    "print(duet.read_noise)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 128,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "hdu_ref20 = fits.open('../astroduet/data/image_library/tel_best/gal_spiral/zodi_low/duet1/best_duet1_spiral_20.0_zodi-low_reference.fits')\n",
+    "hdu_ref21 = fits.open('../astroduet/data/image_library/tel_best/gal_spiral/zodi_low/duet1/best_duet1_spiral_21.0_zodi-low_reference.fits')\n",
+    "\n",
+    "hdu_im20 = fits.open('../astroduet/data/image_library/tel_best/gal_spiral/zodi_low/duet1/best_duet1_spiral_20.0_zodi-low_src-19.80.fits')\n",
+    "hdu_im21 = fits.open('../astroduet/data/image_library/tel_best/gal_spiral/zodi_low/duet1/best_duet1_spiral_21.0_zodi-low_src-20.80.fits')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 129,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "image_rate = hdu_im20[1].data / hdu_im20[1].header['EXPTIME'] *u.ph / u.s\n",
+    "ref_image_rate = hdu_ref20[2].data / hdu_ref20[2].header['EXPTIME'] *u.ph / u.s"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 130,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "0.04304141208418194 ph / s 0.043333333333333335 ph / s 0.02399613107906472 ph / s\n"
+     ]
+    }
+   ],
+   "source": [
+    "image_bkg_mean, image_bkg_median, image_bkg_std = sigma_clipped_stats(image_rate, sigma=2, maxiters=None)\n",
+    "ref_bkg_mean, ref_bkg_median, ref_bkg_std = sigma_clipped_stats(ref_image_rate, sigma=1)\n",
+    "image_rate_bkgsub, ref_rate_bkgsub = image_rate - image_bkg_median, ref_image_rate - ref_bkg_median\n",
+    "print(image_bkg_mean, image_bkg_median, image_bkg_std)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 137,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "0.025343850912321955 ph / s\n"
+     ]
+    }
+   ],
+   "source": [
+    "image_bkg, image_bkg_rms_median = estimate_background(image_rate, bkg_method='1D', diag=True)\n",
+    "ref_bkg, ref_bkg_rms_median = estimate_background(ref_image_rate)\n",
+    "image_rate_bkgsub2, ref_rate_bkgsub2 = image_rate - image_bkg, ref_image_rate - ref_bkg\n",
+    "print(image_bkg_rms_median)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 138,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "<matplotlib.colorbar.Colorbar at 0x11cc93c50>"
+      ]
+     },
+     "execution_count": 138,
+     "metadata": {},
+     "output_type": "execute_result"
+    },
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAawAAAFpCAYAAADA7RyrAAAABHNCSVQICAgIfAhkiAAAAAlwSFlzAAALEgAACxIB0t1+/AAAADl0RVh0U29mdHdhcmUAbWF0cGxvdGxpYiB2ZXJzaW9uIDMuMC4zLCBodHRwOi8vbWF0cGxvdGxpYi5vcmcvnQurowAAIABJREFUeJzt3XuUnHWd5/HPtzud7qTTSTo3CEkgEcIlXAY0A15wBJGLrnOCDmhwRGYWDu6OuOrRPaI7Og6rZ9VVmZldRjcuKKICLl7I0WhEgheUW0AgRAwECKRzIZcOSadDJ93V3/2jnjA1bXfqW11d3fX88n6dU6erq771e35PPdX17d/z/J7vY+4uAADqXcNYdwAAgAgSFgAgF0hYAIBcIGEBAHKBhAUAyAUSFgAgF0hYAIBhMbOLzGydma03s2sHef4vzOwRM+szs0sGPHeFmT2d3a4ILY/zsAAAlTKzRklPSTpfUoekhyRd5u5/KImZL2mypI9JWu7ud2SPT5O0WtJiSS7pYUmvcfddh1omIywAwHCcKWm9uz/r7gck3SZpSWmAu29w98cl9Q947YWS7nL3zixJ3SXponILJGEBAIZjjqSNJb93ZI/V7LXjwl0bAeMmtPr4tmmxYIu3W2iJxzY0FcKxjZ2NscAKdqv2Tg2HFgfKUYUK3rAK/k2ZNLEnHLt3b3xDWAXr1jChLxxb6Itts3Fd8fer8eX4Z6a3LfiZkdTQGw7VuO4KghviG7hnWry/lWjcH49tein2GStMjn++Gg4M/Id+aH0Ta/N/e2FC7EPet3OXCl3dFfwBx1x4bqvv7Ix/dgfz8OP710oq3UDL3H1Zdn+wPkf/sof12lFNWOPbpun4Sz8SivXG+PbbfWJ8o7TO6QrHTv5uWyiu8UD827fjnfEvX++Jf5k0dsVj+1vi/X39q9eFY+//3Ynh2Ibe+PZtO2VnOHZX56RQ3Ix7msNtTnsi/pnZdM7kcOykzfEv1Wn3bw3H9k+Kf7Gv/+v2cGwlpjwVj511Zyz4pbcsDLfZuiWeMXecOiEc6xXktt0nx/7J2Pq5f4k3WoEdnQU9sHJuVW00zX6mx90XD/F0h6R5Jb/PlbQ52HSHpHMGvPaX5V7ELkEAwHA8JGmhmS0ws/GSlkpaHnztSkkXmFm7mbVLuiB77JBGdYQFABgtroLHR/EVt+7eZ2bXqJhoGiXd5O5rzew6SavdfbmZ/bmkH0pql/SXZvaP7n6yu3ea2X9XMelJ0nXu3llumSQsAEiQS+qv6ED4MJbhvkLSigGPfbrk/kMq7u4b7LU3SbqpkuWRsAAgUf1/Mps83ziGBQDIBUZYAJAgl6uQWCUjEhYAJKrWx7BGGwkLABLkkgokrOGzgtS8O/YG7jw13u7kp+InzfZtjJea2Pr62AHLo1fGD2y2/zZ+wuqx74ufffnMt44Px+47Mn7o8onbFoVjp3bH/zj2t8dPHD7io/ETw/u++HIobsfipnCbx1/dEY7d9dWTwrFN3fHPzb7jZ4ZjO86N/1m/avHG8kGZ5x6cVz4o0z0nvn3/+KnYCcHTHo+3uee18ZOBx8U+MpKkwvh47Pjtse1gFZxEX6nURlhMugAA5AK7BAEgQS4x6QIAkA9pnYVFwgKAJLmcSRcAgBxwqZBWvmLSBQAgHxhhAUCCisVv00LCAoAkmQqVXLo9B0hYAJAgl9TPMSwAAEbfqI6wChOknafGhqjHv25DuN0918dLxvS0x8s47TsqFvfiVfHaLrO+ES8Z8/RtJ4Rjd58c31s9/qX4boLdZ+wPx7Y8Fy871bMg3u6GCsrsaPXkUNjxP9sTbnLtH+PlqXqDnxlJ6jwl/lkstFZQ/uuYneHYrq8Pem29QfWe2xfvw73xrxZ/IfZ53HFGfLgwbl84VBNfjMduf138PZh5X+w92Bz/U6gYuwQBAHWvWPyWhAUAyIF+J2EBAOpciiMsJl0AAHKBERYAJMhlKiQ2JiFhAUCiOIYFAKh7KR7DImEBQJJMBU9rl2BaawMASBYjLABIULFae1pjklFNWFaQmvbE9ql2fu2YcLveGu9D19Hxfbqz742Vw+meHSsHJEnPvz1e2mX2r+LleLrmh0PVP76CipgH4h/4qevj/f1/V/1zOPayD380HLtpSU8obvu2tnCb7U8dCMc+d1n8vW1oir9fs+8cH47tb5oWjt35jngNo5a1k8Kxfe/aEY7t+d2MWGBj/P064qH4dpj8aLw2U+Gv4tuh4V3B/t4b/06oFMewAAB1z51jWAAAjAlGWACQqH52CQIA6l3xPKy0dqKRsAAgSekdwyJhAUCCUpzWntbaAACSxQgLABJVoPgtAKDecXkRAEBu9DPpYvisT2rZGSuZ0tMeH8ruOq0Qjp0wc284dvuEWPmeOYs3hdvsXTUnHCvFS9HMvSf+Hmw9sykcO357JR+ReDmcN33/Y+HY/gvj69a0uTkUV2iJf756psXfg5m/ire744wKyjgV4rHtH3g+HNt0/bxwbPcR8T70rQqWW5K0f07sc96ytTHcZuP+3nDsH/7rrHDsrO/F+9DQG3u/bGdtvoZTnNae1toAAJJVNmGZ2Twzu8fMnjSztWb2oezxz5jZJjN7NLu9rfbdBQBEuEwFr+5WbyJj0T5JH3X3R8ysTdLDZnZX9tz17v6l2nUPADBcqZ2HVTZhufsWSVuy+11m9qSkSg7EAABGmbuSq3RR0dqY2XxJZ0h6IHvoGjN73MxuMrP2Ee4bAACvCCcsM5sk6fuSPuzueyR9VdKxkk5XcQT25SFed7WZrTaz1X093SPQZQBAeab+Km/1JjSf0syaVExW33H3H0iSu79Y8vzXJf14sNe6+zJJyyRp4sx5FVzqFgAwXK70dgmWTVhmZpJulPSku3+l5PHZ2fEtSXqHpCdq00UAwHCkdh5WZIT1BkmXS1pjZo9mj31S0mVmdrqKiXyDpPfXpIcAgIq5TP11ODW9GpFZgvdKg+7MXDHy3QEAYHCjWpqpv1nqWhCLnb4mfrhrwqb4aiz4/O5w7J7XtIbitr4cn+V/4OSXw7H75sfXa9LT8XJLLTvDodp9WrzEzYvz4qWkmjbGSihJUssL8XXrDpb52XN8vK+7Kyj9NfPeeF+9tS8cu+lN8c9Cx5PxckuTFsbb7Z4ffx8au+O7omatjsV5Q3ybbT8tvh0mPRMO1a5F8e+liVti70F/Db+FD8ddggCAnHFR/BYAkAumQh1OTa8GCQsAEpTiCCuttQEAJIsRFgAkil2CAIC6527sEgQA5EPBG6q6lWNmF5nZOjNbb2bXDvJ8s5ndnj3/QFZAXWbWZGY3m9ma7FqLn4isDwkLAFAxM2uUdIOkt0papGL1o0UDwq6UtMvdj5N0vaQvZI9fKqnZ3U+V9BpJ7z+YzA6FhAUACXKp1tXaz5S03t2fdfcDkm6TtGRAzBJJN2f375B0Xlaf1iW1mtk4SRMkHZC0p9wCR/UYljdIhZbYmeJb3xyvAjD7F/HV2LQkXgWge070rPb42e8NDfHYmfN2hWO39cwIx/7Hc38Zjr311jeHY18+sScce/Zb1oRjV/1+4D9thxB8f48/bkv5oMz6x+eGY1+eET/IfcmrHw7H/vyFE8Oxe7a0hWMPTI1/Hsd1xf+/7Z0Zr5DS1xKrStE9O/7eNlVwJaNZD+8Lx/a2xStovOHz94fivnHX3nCblbFaV2ufI2ljye8dks4aKsbd+8xst6TpKiavJSpemmqipI+4e2e5BTLpAgASVDwPq+pZgjPMrLR41rLsklHS4DVmB/4HNFTMmZIKko6S1C7pN2b2C3d/9lCdIWEBQKJGoJbgDndfPMRzHZJKd1nNlbR5iJiObPffFEmdkt4j6Wfu3itpm5n9VtJiSYdMWBzDAgAMx0OSFprZAjMbL2mppOUDYpZLuiK7f4mkVe7ukl6Q9GYrapX0Wkl/LLdARlgAkKBaXw8rOyZ1jaSVkhol3eTua83sOkmr3X25ihf/vcXM1qs4slqavfwGSd9Q8cK/Jukb7v54uWWSsAAgUf013onm7is04NqI7v7pkvs9Kk5hH/i6vYM9Xg4JCwAS5C4VDrcrDgMA8qmWuwTHApMuAAC5wAgLABJUnHSR1piEhAUAieLyIlVo6pKO+k2sFMzORePD7W65cH84tqGpPxw7/RctobjOU+LlbfzFWJuS1D3hQDi27Zjd4dizW58Kxz63JF7y6caj7w3HVqRW7UadNLaLl6T/MOWxcOxTJxxZkz7csOzicGzbKWXLwr2i85RpobhCayHc5oRN8a+27qOaw7GFv90Zjv3J/31jKG73jofCbVZihCpd1JW0xosAgGSxSxAAksQxLABATgQuEZIrJCwASBAnDgMAciO1XYJprQ0AIFmMsAAgQbWu1j4WSFgAkCgmXQAA6h4nDgMAMEZGdYRVaJb2HNMYim3oraDhA/G82/RCvAzL9tfFOvHXZ90fbvOyqQ+GY08ePyEcWyvnjHVZJEiSzpkQLyl2zoTNNenD05ffF45tbugLxz7aNjcU997Z8b+zT/zuneHYSR3xMnB798VLqxXeuDcU1/+T+LatVGqzBNklCAApciZdAABywMWkCwBATqQ2wkprBycAIFmMsAAgQSlOaydhAUCiSFgAgLpHaSYAQG6kNkuQSRcAgFxghAUAKXKOYVWloU9q2eGh2K5j4m/0lLVN4dhLrloVjv37GX8Mx8aNfbklYDj+55G/r03Ds9aMeJMnnvOv4di/W/mhcGzTbyeHY6dduDUUt6WxEG6zEswSBADkRmoJq+wxLDObZ2b3mNmTZrbWzD6UPT7NzO4ys6ezn+217y4A4HAVmXTRJ+mj7n6SpNdK+oCZLZJ0raS73X2hpLuz3wEAdeDgtPZqbvWmbMJy9y3u/kh2v0vSk5LmSFoi6eYs7GZJF9eqkwCAyrlbVbd6U9ExLDObL+kMSQ9IOsLdt0jFpGZms0a8dwCAYUvtPKxwwjKzSZK+L+nD7r7HLPZGmNnVkq6WpPGtHOYCgNHgCU5rD504bGZNKiar77j7D7KHXzSz2dnzsyVtG+y17r7M3Re7++JxLa0j0WcAwGEoMkvQJN0o6Ul3/0rJU8slXZHdv0LSnSPfPQDAcB2Ox7DeIOlySWvM7NHssU9K+ryk75nZlZJekHRpbboIAKhcfc70q0bZhOXu90pDHrk7b2S7AwAYKfU4SqrGqFa6KEzp10tv7w7Frnvjt2rcGwCpOr25ORz7u698LRz73g3nhGMf+8GiUFxhT7y0XCVSLM1EtXYAQC5QSxAAUuTFqe0pIWEBQKIO2xOHAQD54Upv0gXHsAAAucAICwCSdBiehwUAyCcmXQAAciG1Y1gkLABIkHt6CYtJFwCAXBjVEZbvb1D/huAlRt5Y274AQKW+Pf+X4djPvm9rKO7//KRrmL0pj0kXAIBcYNIFACAXUjuGRcICgAS56vMijNVg0gUAIBcYYQFAohI7hEXCAoAkJXgeFgkLAFKV2BCLY1gAgGExs4vMbJ2ZrTezawd5vtnMbs+ef8DM5pc8d5qZ3Wdma81sjZm1lFseIywASFQtdwmaWaOkGySdL6lD0kNmttzd/1ASdqWkXe5+nJktlfQFSe82s3GSvi3pcnd/zMymS+ott0xGWACQqGI9weHfyjhT0np3f9bdD0i6TdKSATFLJN2c3b9D0nlmZpIukPS4uz9W7KfvdPdCuQWO6gjr1Onb9eDlXx3NRQLAmDi79alQ3Hcaemqy/BG64vAMM1td8vsyd1+W3Z8jaWPJcx2Szhrw+ldi3L3PzHZLmi7peEluZislzZR0m7t/sVxn2CUIAClySdUnrB3uvniI5wZrfOC4bKiYcZLOlvTnkvZJutvMHnb3uw/VGXYJAgCGo0PSvJLf50raPFRMdtxqiqTO7PFfufsOd98naYWkV5dbIAkLABJV42NYD0laaGYLzGy8pKWSlg+IWS7piuz+JZJWubtLWinpNDObmCWyN0n6g8pglyAApKqG52Flx6SuUTH5NEq6yd3Xmtl1kla7+3JJN0q6xczWqziyWpq9dpeZfUXFpOeSVrj7T8otk4QFAEmqffFbd1+h4u680sc+XXK/R9KlQ7z22ypObQ8jYQFAqqh0AQDA6GOEBQApovgtACA3EtslSMICgGQxwhq2/V7QM717Q7HHNk2qcW8AoHbOmdAfimtjJkEYIywASBW7BAEAuUDCAgDUvZEpfltXSFgAkKhAPcBc4XAfACAXGGEBQKoSG2GRsAAgVRzDAgDkgTHCAgDUPVdyuwSZdAEAyIVRHWE1WyMllwBgVBjHsAAAOXG47RI0s5vMbJuZPVHy2GfMbJOZPZrd3lbbbgIAKuZV3upM5BjWNyVdNMjj17v76dltxch2CwCAf69swnL3X0vqHIW+AABG0mE4whrKNWb2eLbLsH2oIDO72sxWm9nq7TsLVSwOABB2sPhtNbc6M9yE9VVJx0o6XdIWSV8eKtDdl7n7YndfPHN64zAXBwColHl1t3ozrFmC7v7iwftm9nVJPx6xHgEARkYdJp1qDGuEZWazS359h6QnhooFAGAklB1hmdmtks6RNMPMOiT9g6RzzOx0FfP3Bknvr2EfAQAon7Dc/bJBHr6xBn0BAIygejwOVQ0qXQBAqupwpl81SFgAkKI6PZeqGlRrBwDkAiMsAEhVYiMsEhYAJIpJFwCAfEgsYXEMCwCQC4ywACBViY2wSFgAkKB6LWBbDRIWAKSKE4cBALmQ2AiLSRcAgFxghAUAieIYFgAgH0hYAIC6l+AsQY5hAQBygREWAKQqsREWCQsAUkXCAgDkAcewAAAYAyQsAEAujOouwY29E/XhLYtDsf80e3WNewMAtfP3204NxW3q21G7TiS2S5BjWACQogTPwyJhAUCqSFgAgFxILGEx6QIAkAuMsAAgQSaOYQEA8oKEBQCoewnOEuQYFgBgWMzsIjNbZ2brzezaQZ5vNrPbs+cfMLP5A54/2sz2mtnHIssjYQFAqrzK2yGYWaOkGyS9VdIiSZeZ2aIBYVdK2uXux0m6XtIXBjx/vaSfRleHhAUAqaphwpJ0pqT17v6sux+QdJukJQNilki6Obt/h6TzzMwkycwulvSspLXR1RnVY1jzmvaFSy79bF9zuN2LJu4fbpcAIOzvNr02HPvTx04JxXV2Pzjc7pQ1AsewZphZ6Zf2Mndflt2fI2ljyXMdks4a8PpXYty9z8x2S5puZi9L+rik8yWFdgdKTLoAgHRVn7B2uPtQBWAtsMShYv5R0vXuvjcbcIWQsAAAw9EhaV7J73MlbR4ipsPMxkmaIqlTxZHYJWb2RUlTJfWbWY+7/+9DLZCEBQApih2HqsZDkhaa2QJJmyQtlfSeATHLJV0h6T5Jl0ha5e4u6Y0HA8zsM5L2lktWEgkLAJJVy/OwsmNS10haKalR0k3uvtbMrpO02t2XS7pR0i1mtl7FkdXSapZJwgKAVNX4xGF3XyFpxYDHPl1yv0fSpWXa+Ex0eSQsAEgUlS4AABgDjLAAIFWJjbBIWACQotrPEhx1JCwASJBp8LN282xUE9a6nqk6d+3AUlPVW3zid8OxMxpbR3z5APJr4S3/ORz7F29aE46df8z2UFxnc1+4zcMdIywASFViuwTLzhI0s5vMbJuZPVHy2DQzu8vMns5+tte2mwCASplXd6s3kWnt35R00YDHrpV0t7svlHR39jsAoJ7U9vIio65swnL3X6tYUqNU6TVObpZ08Qj3CwBQrcMtYQ3hCHffIknZz1kj1yUAAP5UzSddmNnVkq6WpOZZbbVeHABAkur0OFQ1hjvCetHMZktS9nPbUIHuvszdF7v74qapE4e5OABAxdglKOnfrnGi7OedI9MdAMBIOexmCZrZrSpefOsEM+swsyslfV7S+Wb2tKTzs98BAPUksRFW2WNY7n7ZEE+dN8J9AQBgSKNa6eJAT5OeX3dkKLZp5svhdtf3toRjb91zTDj2g+3Ph2MB1I8fdU8Kx75q8cZw7K/uPSUcW2grhOIO7K/d13A97tarBqWZACBFdbpbrxokLABIVWIJiysOAwBygREWACTIxDEsAEBekLAAAHlgnlbGImEBQIoSnCXIpAsAQC4wwgKARDHpAgCQDySsKhSkxu7YXsj/9pYV4Wb/9psfDMf2LNgfjn30pHWhuAUTd4TbvL9zQTj2vbPvD8cubdsVjgVq7bau9nDsw93zQ3H3bYv/7ZwwdcgrHv2J3fvjpd0K03vDsdPvHR+K295t4TYrxQgLAJAPiSUsJl0AAHKBERYApKhOL8JYDRIWAKSKhAUAqHcp1hLkGBYAIBcYYQFAqqglCADIg9R2CZKwACBFCRa/JWEBQKKsf6x7MLLqNmHduvSCcOyE18X/jeg7sRCOXffSrFDcfT8+LdxmoSXe109MnxeO/effxOfPNL4vXrbm3tN+EI5FZS5++sJw7I8WrgzHLvzl34Rj/8uf3ROO/ZfHzg3HVmLeN2NfQ7teEyt1JEmPdB0Zjm19+9ZwbPMLzeHYztNi2aIQ37SHvbpNWACAKrFLEACQB0y6AADUPxfT2gEA+ZDaCItKFwCAXGCEBQCpSmyERcICgASlWPyWhAUAKXJPbtIFx7AAALnACAsAEsUuwSo0FKTmTgvFPnvJlHC7c1cdCMc27Z0Qju1VLHbChPinotASW39Jat3UGI7d+ubecKy2tIdDF3RcFY6dPKM7HNvzxNRw7NlvWROO/eV9p4Ti+tv6wm02b4qXBFp8/h/CsRv3xD/jj+7fH44dv2ZiOPYr+84Px1byPhzz073h2KeCH7FpD9bm76xzb/z9atkZDlVTV2wHVkP866tyJCwAQB4wwgIA1D+X1J9WxmLSBQAgFxhhAUCq0hpgkbAAIFUcwwIA5AMnDgMA8sC8ulvZ9s0uMrN1ZrbezK4d5PlmM7s9e/4BM5ufPX6+mT1sZmuyn2+OrA8JCwBQMTNrlHSDpLdKWiTpMjNbNCDsSkm73P04SddL+kL2+A5Jf+nup0q6QtItkWWSsAAgRT4Ct0M7U9J6d3/W3Q9Iuk3SkgExSyTdnN2/Q9J5Zmbu/nt335w9vlZSi5k1l1sgCQsAElSs1u5V3cqYI2ljye8d2WODxrh7n6TdkqYPiPkrSb9397LlXEZ10sXEqT06fUmsdM0Dvzkp3O7eOfGSMdsXxw9CNu+M5fPGeNUcHZgaX35fW384tpKySJO/NTkcu+3dL4djuzri7Y4vxEvnPP0/Bu5lGFr7jFi7fa3xz8y+2fFt9siKeF/3T49v33c++6FwrM+Pl+mqpNxS02kvhWOfXRhvd/7M7aG4jp1Hhdu8+Pz7wrGrvvbacOzeo+OfhWO/FPuu69jTE26zYvGP2FBmmNnqkt+Xufuy7P5gf2wD36BDxpjZySruJrwg0hlmCQIAhrLD3RcP8VyHpHklv8+VtHmImA4zGydpiqROSTKzuZJ+KOl97v5MpDNVJSwz2yCpS1JBUt8hVgwAMMoCu/Wq8ZCkhWa2QNImSUslvWdAzHIVJ1XcJ+kSSavc3c1sqqSfSPqEu/82usCRGGGd6+47RqAdAMBIiU2cGH7z7n1mdo2klZIaJd3k7mvN7DpJq919uaQbJd1iZutVHFktzV5+jaTjJH3KzD6VPXaBu2871DLZJQgASar9FYfdfYWkFQMe+3TJ/R5Jlw7yus9K+myly6t2lqBL+nl24tfVgwWY2dVmttrMVve8VMODiwCAf6fWJw6PtmpHWG9w981mNkvSXWb2R3f/dWlANqNkmSRNP2lmHb4FAIA8qGqEdfDEr2y/4w9VPJEMAFAP3Ku71ZlhJywzazWztoP3VZxH/8RIdQwAUAWXrL+6W72pZpfgEZJ+aGYH2/muu/9sRHoFAKheHY6SqjHshOXuz0r6sxHsCwAAQxrVae37t7bo+S+dEIrtO78Qbnfb6+N9aOyO7wWNls5ZcGe8FM5zS5rCsc3bGsOxTb+fGo7delY4VJMnxmd27uluDccu+H5nOPaPH4m32/5g7D3rGVjN7BCOvD/+Wew+Ir7N5p3bEY7t+vrccOzOd8Rrhc1cGf972Dw5Xnpr0gvxdsc9EizT9bZwk1r73oXh2BmT42XNXjppYjh2/cdjZbr2/6+V4TYrltYAi/OwACBVNa50MepIWACQKhIWAKDuuUaiWntd4XpYAIBcYIQFAAkyhS7CmCskLABIFQkLAJALJCwAQN1j0gUAAGNjVEdY3ijtnxzLkUetiv9r0NcSz7s7LoxXbjj267G43knxt9Gmx6sQtN/XHI7deUqwWoCkxp54bN+qGeHYpnhBCm0+b1o4dvbK+Gehe3Zs3ZpfCjeptke3xINPnx0O3XXLvHBs+4Z4NYbG2yeEYyetjNernrAwXolt4ovxbfbMO2Ofc2/pC7e5/vJ4KRN7Vfy9nXR//Ltm35Gx3XG13GnHpAsAQD6QsAAA9a8+r2lVDY5hAQBygREWAKTIldwIi4QFAKlKbFo7CQsAEsUsQQBAPiSWsJh0AQDIBUZYAJAil9Sf1giLhAUASUrvPKxRT1hWiMXtene8XMqsb1RQimZSvDRTx5vaQ3EtneEmNf6ppnDsy/GqSDowPV62ZtbvGsOx214f3GCSjrutNxy749T4Ntu9IL7n+oiHD4Titp0xPtxmz7GzwrEd58fLXnlL/P2a+nT8Pdi0JN7ulKPi5ZZqpXlnbN32z4p/+c69J/4ebO2eFI7tOj3+/dEULCVlzTWcykfCAgDkQmIJi0kXAIBcYIQFACli0gUAIB9c8rRKXZCwACBVHMMCAGD0McICgBRxDAsAkBuJ7RIkYQFAqkhYAID6R2mmqhSmFtS1pCsU+/LOeOmePUfHV6Pr+Snh2BPv2BGK23Hm9HCbbRvjpY52Loqv1/TV8XJLe+fGywedcOO+cOwzl7aFY/umVlA+aG28nNXeo2KxM56IL3/vnHgZp0rKLU17ML5e214T78O4zfEvqQk74tOee6bF52g19Mb7MO/u2Gdsw9vj3wnPvzX+Ge+fuj8ce8z34n9nXf9pbyiuoSGtqee1xAgLAFLkkvrTSoYkLABIFbsEAQC5QMICANQ/T+48LCpdAABygREWAKTIJaf4LQAgFxIUWxxgAAAF4UlEQVTbJUjCAoBUJTbpgmNYAIBcYIQFACly58ThajS+1KhJP46V7ykcF2/35ZnxMiwTtsZjn18yIxQ3rifcpArj46VdJj8f/7Btf3W8D5NeiL8HPi4+CO+bdSAc27gzXpaoEK9KpLYXYn144ap4iawpd8f/TMa3xd+D5j3xdnee1x2O7X2pORw7PlYpTZLUf3K8TFfjYy3h2KffF/sszLwv3KS2vy6+fVuei79fvRPj7XZujpWBK/TGvxMqltguQUZYAJAoT2yEVdUxLDO7yMzWmdl6M7t2pDoFAKhWVq29mludGXbCMrNGSTdIequkRZIuM7NFI9UxAABKVbNL8ExJ6939WUkys9skLZH0h5HoGACgCi7OwyoxR9LGkt87JJ01MMjMrpZ0tSSNb22vYnEAgIpQ6eIVg001+5N07u7LJC2TpNYZ89JK9wBQp1ySJzbCqmbSRYekeSW/z5W0ubruAABGhHtxhFXNrYxyE+/MrNnMbs+ef8DM5pc894ns8XVmdmFklapJWA9JWmhmC8xsvKSlkpZX0R4AICeCE++ulLTL3Y+TdL2kL2SvXaRizjhZ0kWS/jVr75CGnbDcvU/SNZJWSnpS0vfcfe1w2wMAjCzv96puZbwy8c7dD0g6OPGu1BJJN2f375B0nplZ9vht7r7f3Z+TtD5r75CqOnHY3VdIWlFNGwCAGqntpIvIxLtXYty9z8x2S5qePX7/gNfOKbdA81E8OczMtkt6fsDDMyTtGLVOjK5U1431yp9U1y2F9TrG3WeOdKNm9jMV359qtEgqLT63LJtIJzO7VNKF7n5V9vvlks509w+W9GFtFtOR/f6MiiOp6yTd5+7fzh6/UdIKd//+oTozqqWZBtsoZrba3RePZj9GS6rrxnrlT6rrlup6jQR3v6jGi4hMvDsY02Fm4yRNkdQZfO2f4PIiAIDhiEy8Wy7piuz+JZJWeXG33nJJS7NZhAskLZT0YLkFUvwWAFCx7JjUwYl3jZJucve1ZnadpNXuvlzSjZJuMbP1Ko6slmavXWtm31OxMlKfpA+4e9lS+PWQsJaNdQdqKNV1Y73yJ9V1S3W9cmGwiXfu/umS+z2SLh3itZ+T9LlKljeqky4AABgujmEBAHJhTBNWqtfTMrMNZrbGzB41s9Vj3Z9qmNlNZrbNzJ4oeWyamd1lZk9nP3NX1XiI9fqMmW3KttujZva2sezjcJjZPDO7x8yeNLO1Zvah7PEUttlQ65b77YaYMdslmJXheErS+SpOcXxI0mXunvvLk5jZBkmL3T3v54fIzP5C0l5J33L3U7LHviip090/n/2j0e7uHx/LflZqiPX6jKS97v6lsexbNcxstqTZ7v6ImbVJeljSxZL+RvnfZkOt27uU8+2GmLEcYUXKemCMufuvVZzdU6q03MrNKn5p5MoQ65V77r7F3R/J7nepWDZtjtLYZkOtGw4TY5mwBivrkcqHzyX93Mwezq4Hlpoj3H2LVPwSkTRrjPszkq4xs8ezXYa5221WKquMfYakB5TYNhuwblJC2w1DG8uEFbqeVk69wd1frWIV4w9ku59Q/74q6VhJp0vaIunLY9ud4TOzSZK+L+nD7r5nrPszkgZZt2S2Gw5tLBNWstfTcvfN2c9tkn6oQBXinHkxO55w8LjCtjHuz4hw9xfdveDu/ZK+rpxuNzNrUvEL/Tvu/oPs4SS22WDrlsp2Q3ljmbCSvJ6WmbVmB4RlZq2SLpD0xKFflTul5VaukHTnGPZlxBz8Qs+8QzncbtmlG26U9KS7f6Xkqdxvs6HWLYXthpgxPXE4m376T/q3sh4VnfVcj8zsVSqOqqRiJZHv5nm9zOxWSeeoWPX5RUn/IOlHkr4n6WhJL0i61N1zNYFhiPU6R8XdSi5pg6T3Hzzukxdmdrak30haI+ngtSU+qeKxnrxvs6HW7TLlfLshhkoXAIBcoNIFACAXSFgAgFwgYQEAcoGEBQDIBRIWACAXSFgAgFwgYQEAcoGEBQDIhf8PlJ/jA738HI4AAAAASUVORK5CYII=\n",
+      "text/plain": [
+       "<Figure size 576x432 with 2 Axes>"
+      ]
+     },
+     "metadata": {
+      "needs_background": "light"
+     },
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "plt.figure(figsize=[8,6])\n",
+    "plt.imshow(ref_image_rate.value, cmap='viridis', aspect=1, origin='lower', vmin=0, vmax=0.1)\n",
+    "plt.colorbar()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 139,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "<matplotlib.colorbar.Colorbar at 0x11e0ca518>"
+      ]
+     },
+     "execution_count": 139,
+     "metadata": {},
+     "output_type": "execute_result"
+    },
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAaUAAAFpCAYAAAA8+DdhAAAABHNCSVQICAgIfAhkiAAAAAlwSFlzAAALEgAACxIB0t1+/AAAADl0RVh0U29mdHdhcmUAbWF0cGxvdGxpYiB2ZXJzaW9uIDMuMC4zLCBodHRwOi8vbWF0cGxvdGxpYi5vcmcvnQurowAAIABJREFUeJzt3W2MXNd93/Hfb2Z3SYmW9UQ/sBJtpbZQ1E0Q2SVkBy4CJa4TWQgiG7UL6UUiBy7oBhZqFwlQxy9kV0ABp43tInBqYw0JlgPHseFHNiCqqI4LOUCjmBJkWRSdiDWUiCJBhqRE8WGfZubfFzu0JqvdnXN25s7ce/j9AIPdnT175tx5+u+599zfOCIEAEAdtKY9AAAALqIoAQBqg6IEAKgNihIAoDYoSgCA2qAoAQBqg6IEAMhme7vtv7b9Q9sHbf/nddpss/1V24dtP2L7hmH9UpQAAFuxJOmXI+LnJd0k6Vbbb1vT5gOSno+IN0r6jKTfH9YpRQkAkC1Wnev/ONu/rE1juF3SA/3vvy7pHba9Wb8UJQDAlthu235c0glJD0XEI2uaXCfpWUmKiI6kM5Ku3azPmSoGupGd17Tjht2zY++3o15y26XYtEj/I4u9tLFe6M0l97nQTd/+5U76wxOd9O1yTttuclO1Oultc/p1Lz0KK6dtqmil319ZbdvpY+hltI2MV3XMZNy3GW3nZtKfDJe1V9LatdLaSdL21nJy220Z7x8zTv8/3kp7Ljzz7IpOnu6mP3ES/eov7YhTpzNeaOt49Imlg5IWB66aj4j5iz9ERFfSTbavkvQt2z8bEU8OtF9vuzZ9Ik20KN2we1Z//eDusfd7sns+ue1POukF5MdLu5La/fD865L7PHgmrU9J+rtT1yS3XTx5WXLbuZPp73DbT6e/VradTn/T2vZi+hvB7Pn0F1Z7abQX4Xq629Lvr5Ud6W2XXpn+Brd0dcY/U9emPw7L16bfX9t2LiS33X3tC8lt/8VVx5La/dzlR9L73PZcctvXz6Rv1852+uts1mnPhZt/9dnkPnOcPN3VIw9eP1Ifs7v+32JE7BnWLiJesP1/JN0qabAoHZG0W9IR2zOSrpR0erO+2H0HAMhm+1X9GZJsXybpX0v68Zpm+yTd1f/+vZL+IoakgE90pgQAmJRQN9L3SGzBLkkP2G5rdYLztYj4M9v3SjoQEfsk3Sfpj20f1uoM6Y5hnVKUAKBAIam3+eGb0fqPeELSm9e5/p6B7xclvS+nX4oSABSql7GIoy44pgQAqA1mSgBQoFCo28BPFqcoAUChqjymVBWKEgAUKCR1KUrjsxTpZ28vZkxRVzJOo1+MtBNtc/rsRvphvKyZd0ZbV9RvZSpIaajq9p3xoFX1OLiXkdiRkXASGW17GW07iXEVOa+zZWWc8JzcUlqJ9JONW4mJDlHhi6yJMyUWOgAAaqO2MyUAwNaFxEIHAEB9NO8sJYoSABQpFCx0AADUREjd5tUkFjoAAOqDmRIAFGg1kLV5KEoAUCSrm3iuVJ1QlACgQKHpn3e+FRxTAgDUxkRnSh319Hz3QlLblYyljGcSY0ok6YXe5cltz3W3J7U739mW3OfCymxy204nfbvcyYiW6ea0TW6qVsZSH2dF96SPoYrlRk5/GLLur5z7oFXRY6aM50034/m42El/a3kx8fVzppv+2n0ho+1pLyW3bWk5ue12pwUYVblsm913AIBaWA1kpSgBAGoiJxi3LihKAFCgps6UWOgAAKgNZkoAUKCQ1W3gvIOiBACF4pgSAKAWmnpMiaIEAEWyutG83XfNGzEAoFjMlACgQKsp4c2bd0y0KK2EdDQxLmUx0od2qrsjue1zK9cktz2+8sq0219Kv/0Ly+kxQ73l9FiX1kr6vuNWWvrJattORhxQTiRRVr/VxBdV0WfOWFudjDFk3F9VPRe6y+lvcOcW06O3XrgsLRLoxPIVyX1e2b46uW3b6R/wsKyzyW3nEj84YrnC0FSOKQEAaiGCY0oAAIyEmRIAFKrH7jsAQB2snqfUvJ1hFCUAKFIzjylRlACgQE1dEt68EQMAisVMCQAK1SWQFQBQB3x0BQCgVnosdNjcUszo6ZVXJbVdjvSIndOdVyS3PbKcHjP03MJVabe/mBaTIknnF9LjV2IxI2ZoqaKYoYy27ZWMOJ6cmKFOegxMTtvkPlvp96276W8COVFLVUUHtTOeN92M5+PCYnqc1qmFtNfP5TNpr0dJmmmlPw9WMiLNXphJjxSbdVqO1GKcSu4zR1OXhDdvxACAYg0tSrZ32/6e7UO2D9r+cP/6T9h+zvbj/ctt1Q8XAJAiZHVjtMs0pMxbO5J+JyIes32FpEdtP9T/3Wci4g+qGx4AYKuaeJ7S0KIUEcckHet/f9b2IUnXVT0wAMDWRaiRiQ5ZI7Z9g6Q3S3qkf9Xdtp+wfb/t9A8wAQBgHclFyfYrJH1D0kci4kVJn5P0Bkk3aXUm9akN/m6v7QO2D5w5nfGpZgCAEVi9ES/TkLQW0vasVgvSlyPim5IUEccHfv8FSX+23t9GxLykeUl6489dXuFnLAIALgoVuvvOtiXdJ+lQRHx64PpdA83eI+nJ8Q8PALBVXbVGumxmo5XZa9rcYvvMwCrte4aNOWWm9HZJvyHpR7Yf71/3MUl32r5JqwX5GUkfTOgLADABIatX7bLudVdmR8RTa9p9PyJ+LbXTlNV3fymtu3Nxf+qNAADKssnK7LVFKctEY4YWenN6aiFtNflSRvTHmc5lyW1PLF6R3PbYhVcmtTt9Pj1maPn8XHLb1oX0/cEzC+n/EbUXk5uqvZTetpURM9ReTo+BaeXEDK2MP2aolREzlLNdvaWMx3cp/b7tLmZEB+U8bzKejytz6c/z52fSXj9tp98HOTOE85306K+rZi8kt511N6ndYu9wcp+5xhAztNP2gYGf5/vrBP6RdVZmD/oF2z+UdFTS70bEwc1ukEBWAChQaCyBrCcjYs9mDdZZmT3oMUmvj4hz/dSfb0u6cbP+mrc0AwCQwOqOeBl6C+uszB4UES9GxLn+9/slzdreuVmfzJQAoEBjmiltaKOV2WvavFbS8YgI2zdrdSK0aSw6RQkAsBUbrcx+nSRFxOclvVfSb9vuSFqQdEdEbHpwkKIEAIVK2QW3VZuszB5s81lJn83pl6IEAAWKMJ88CwCojyJjhgAAmBRmSgBQoJCmlvQ9igknOszqybP/JKltJ2PaeW4l/YzsM0vbk9u+cD4tKWLhbHqfPtdObjtzPuNs+4XkpppZSD8zPidJoJ3RtpWRfOCVtDPjc9tWodVOf97m3AftpZzEjozHNyPRoTeX0XYm/a1loZX2+j2Z3KO03E1/nZ3Zlp4Is2M2PeJkppX2+C50Z5P7zONG7r5jpgQABVo9T4mZEgCgJsaQfTdxzRsxAKBYzJQAoEAT+DylSlCUAKBQvQbuDKMoAUCBIqQuMyUAQF00cfdd8+Z2AIBiMVMCgAKtLnRo3ryDogQAharyoyuqMtGitNSZ0eEXNv0k3J/q9tLvzOVO+mYsLswlt+0spPXrc+m3P3sufbtmM2KGZs/nRMvktM2IwllMj/hpLWdEBy3lxAx1kttWobWc/p9peym97cxCetvebPrj28t4B4h2+vMx5x/0TqTF7Cx00jtdXk7fsLPb0mPK5mYynuOJMUNL3Wrehpua6NC8uR0AoFjsvgOAInFMCQBQI3x0BQCgFjh5FgBQK03cfde8EQMAisVMCQAKREo4AKBWWOgAAKgFTp4FAGBEE50pdbptnTx1RVrjjJihWEmvrc6JgVlIG8PMhfSxzuREB51NbqrZ8xltL6TH0LQXMmJVcuKAllbS2y5ntO2kjyFZpN9fOf/mtXNiezLa9mYz2mb0K2fcDxm7jdxNa9tdTu+zmxHhdGEuLeZIki7MpsduOXG43U47uc9cTVx9x+47AChRsNABAFATIRY6AABqpIkzpebtcAQAFIuZEgAUqKlLwilKAFAoihIAoBaIGQIA1EoTV9+x0AEAUBvMlACgRMExpeFWrNY/zKW1zUg0cSf9jm+lJ9aovZgYM7SQ3udMRsRPTnTQ3Pn0+JOZC+lRPDMZMUPthYw4oKVOetuV9LaqIGbIvfT7NkcrNYdGUruVEU+VEx2UwRlvcM64y1oraf12El+PktRdSI/u6c2l7zCKjESgaCW+1jPev3Kw+g4AUCtNLEpD/0Wwvdv292wfsn3Q9of7119j+yHbT/e/Xl39cAEAJUuZt3Yk/U5E/HNJb5P0IdtvkvRRSd+NiBslfbf/MwCgBi4uCR/lMg1Di1JEHIuIx/rfn5V0SNJ1km6X9EC/2QOS3l3VIAEA+SI80mUaso4p2b5B0pslPSLpNRFxTFotXLZfPfbRAQC2rInnKSUXJduvkPQNSR+JiBeduHLI9l5JeyWpfTWHnQBgEqKhS8KT1kLantVqQfpyRHyzf/Vx27v6v98l6cR6fxsR8xGxJyL2tHfsGMeYAQCFSll9Z0n3SToUEZ8e+NU+SXf1v79L0nfGPzwAwFZVeUxpo5XZa9rY9h/aPmz7CdtvGTbmlN13b5f0G5J+ZPvx/nUfk/RJSV+z/QFJfy/pfQl9AQAmovIVdBdXZj9m+wpJj9p+KCKeGmjzLkk39i9vlfS5/tcNDS1KEfGX0oZHy96RMnIAwORVuYKuv9Dt4mK3s7YvrsweLEq3S/pSRISkv7J9le1dFxfJrWeiiQ6tjrTt5PgzYFsZKTRZMUNLaTEh7aX0PmcWMmKGFnKigzLank+/w1oXMqKDFpbT2y6lt1VOzFA3LWZo9TWSxjPpL5Ost4CcmKGMtll6GfdDLz1jp9VJf52nvn7a25O7VHdb+v3Vm01vmxMzlPr45rx/5RhTzNBO2wcGfp6PiPm1jdaszB50naRnB34+0r+uHkUJANAoJyNiz2YN1q7MXvvrdf5k0/+EKEoAUKJYXRZepQ1WZg86Imn3wM/XSzq6WZ98nhIAFKonj3TZzCYrswftk/Sb/VV4b5N0ZrPjSRIzJQAoUqjahQ7aeGX26yQpIj4vab+k2yQdlnRB0m8N65SiBADINmRl9sU2IelDOf1SlACgSNNL+h4FRQkAClX1QocqUJQAoFDT+viJUVCUAKBAEc0sSiwJBwDUxkRnSu5Il51M3MmZsS/U6Qk7eTFDK4kxQ8vpg20vZsQBLaRF5khSazG9bXuhBtFBGW2jk75t6mW0Tb39xOgiSXIv/fHN+h824+BAOydCKSNmqNXJaLucnsczs5h2T3S2pf8P3ZtNH2tvJiOSKCtmKLFZRTFDUjM/T4nddwBQKBY6AABqo4nHlChKAFCg0PAP6qsjFjoAAGqDmRIAFKqBh5QoSgBQpIaep0RRAoBSNXCqxDElAEBtMFMCgEKx+w4AUBucPDtEqyNddioxhiUrZqiaqBQntm0vp0fLtJYyooOWM+JtFtOzSnLigLyckcuUFR2Uka2S0Ta6GZlTidxO38sdORE/OW1ztisj6qjdyYhFWsl47i6lv7XEXNr9OzObEzOU8ZhlxAxFRsxQOK3fVkUxQxP45NlKMFMCgBKFpAYWJRY6AABqg5kSABSKY0oAgPqgKAEA6qGZgawUJQAoVQNnSix0AADUBjMlACgRgawAgFpp4O47ihIAFIuZ0qZanZ62n0qMoslJi8mKa8mJJEobRE78Sk5brWREB2W0zek3VjJihnKig3LG0M24z1KfCxlRPNHNOPTazokDyvg3NiNmyBnbpk5O7FX620VrNiNmaDYtu6ed2E6SYiYjZqiVETOU0TZV6vvMpYKZEgCUit13AIDaoCgBAGqhoYGsFCUAKFQTs+84eRYAUBvMlACgVA2cKVGUAKBUHFMCANSFmSkBAGoh1Mjddyx0AADUxkRnSu6GZk4tpLXNWctYVdvEaBdnRLUoJzIno9/IifjJGkNOHFBGXErGGLJihnKie5IHkBFjlRNflNHWOfdXL+fxTX8L8FLG/7AzGf3OpMUHRTvj9ls50VAZbT3+YzSuLGbIHFMCANRIibvvbN9v+4TtJweu+4Tt52w/3r/cVu0wAQDZYsTLFKTMW78o6dZ1rv9MRNzUv+wf77AAAJeioUUpIh6WdHoCYwEAjFOhM6WN3G37if7uvas3amR7r+0Dtg8sd86PcHMAgGQXA1lHuUzBVovS5yS9QdJNko5J+tRGDSNiPiL2RMSeuZkdW7w5AEAux2iXadhSUYqI4xHRjYiepC9Iunm8wwIAjKzi3XfrLYRb8/tbbJ8ZWBR3z7A+t1SUbO8a+PE9ktYdEACgaF/U+gvhBn1/YFHcvcM6HHqeku2vSLpF0k7bRyR9XNIttm/Sai19RtIHh/UDAChLRDxs+4Zx9jm0KEXEnetcfd84BwEAGL+aBLL+gu0fSjoq6Xcj4uBmjSeb6NDtqnXm3Pj7rSpmKDEGJicuJiviJysSKSe2p6Lx5kTsZD0OOY9vBZEtvfS93JGzjrayeKz0x8ztjBipVsZqrHZadJAkqZXYNuP2nRMHlNM2J74oVc7rMdfoK+h22j4w8PN8RMxn/P1jkl4fEef6IQvflnTjZn9AzBAAlGg85xqdjIg9Wx5CxIsD3++3/T9s74yIkxv9DSnhAIBK2H6t+9NW2zdrteac2uxvmCkBQKkqPqa0wUK4WUmKiM9Leq+k37bdkbQg6Y4Ysu+eogQAhap6ocMGC+EGf/9ZSZ/N6ZOiBAClqsfquywcUwIA1AYzJQAoVQNnShQlACjQNENVR0FRAoBSTenjJ0Yx4USHnuJcBZ+pVMVZ/FJekkCivCSDjO2qqN/KkhdyVPX4Tvv2c5IieunJCznJB1mJHVlpBivpTVMTFTJuP+eZmJX+UIVexmOQq4EzJRY6AABqg913AFAojikBAOqDogQAqIWGrr7jmBIAoDaYKQFAqRo4U6IoAUCpKEoAgLrgmBIAACOgKAEAamOyu+96PcXCwkRvchRZETtNUlUcEPJUFV+UkVoTzvi/tDvluKeKTPvVEFW+Hqe9cVvAMSUAKFFDz1OiKAFAqShKAIDaaGBRYqEDAKA2mCkBQIEsjikBAOqEogQAqIWGrr7jmBIAoDaYKQFAqRo4U6IoAUCpKEqbiwj1llcmeZMv45anevuVyYmLaZqSty1VVZFEGf1WGoeTNoDp3n5VKowza+IxJWZKAFCqBhYl/gUFANQGMyUAKFGokTMlihIAFIpjSgCA+qAoAQDqookzJRY6AABqg5kSAJSqgTMlihIAlIjVdwCAunD/0jSTL0pTjgqJbkbjCuJtGhdzVNF47YbdD4miqsiYXkWHf+sQ3ZM6hgrjeFAfzJQAoFQNrOND//2yfb/tE7afHLjuGtsP2X66//XqaocJAMjlGO0yDSn7BL4o6dY1131U0ncj4kZJ3+3/DACokxjxMgVDi1JEPCzp9Jqrb5f0QP/7ByS9e8zjAgCMqsSitIHXRMQxSep/ffX4hgQAuFRVvtDB9l5JeyVpuy6v+uYAAJI0xeNCo9jqTOm47V2S1P96YqOGETEfEXsiYs+stm3x5gAA2S6h3Xf7JN3V//4uSd8Zz3AAAONS9eq79VZnr/m9bf+h7cO2n7D9lmF9piwJ/4qk/yvpn9k+YvsDkj4p6Z22n5b0zv7PAIA6qX6m9EW9fHX2oHdJurF/2Svpc8M6HHpMKSLu3OBX7xj2twCAckXEw7Zv2KTJ7ZK+FKtRJ39l+yrbuy4ulFvPpZfoMO3ooApuX1JWHFBWxE+rovEWGjPkqqJwnB4HlBV1lBFf5FbGGHoZY0h+TWREIhFJJGksCx122j4w8PN8RMxn/P11kp4d+PlI/zqKEgBcUsazWOFkROwZ4e/X++9z01FRlACgVNOfMB6RtHvg5+slHd3sD/jkWQBAVfZJ+s3+Kry3STqz2fEkiZkSABTJqv7k2f7q7Fu0euzpiKSPS5qVpIj4vKT9km6TdFjSBUm/NaxPihIAlKriorTJ6uyLvw9JH8rpk6IEAIWqbDVohShKAFCiKUYFjYKFDgCA2mCmBACFamJKOEUJAEpFURrCktvtid7ky8dQwR7LqiJ+ssaQsV01iBmq7H6YsqyInxwZ91fWwe2s+KKc53kF90PG7WfFHGWNISPqKLnP8Xd5ETMlAEB9NLAosdABAFAbzJQAoEQN/Th0ihIAlIqiBACog0lk31WBY0oAgNpgpgQApSL7DgBQF03cfUdRAoASNTSQlaIEAIXKCOyojQkXJUuJMUO1iKFJjdipQXRQ1v2VEYuUpYoIJ6m68abKiKzJGmlOZE07477NGG9OLJJ7GePNOZaR2G9WzFFOmllWJFEFMWkrNXivqxFmSgBQKnbfAQDqgoUOAIB6CLEkHABQH02cKZHoAACoDWZKAFCqBs6UKEoAUKCmBrJSlACgRBGNXOjAMSUAQG0wUwKAQrH7bgjb8tzcJG9y3TGMXR1ieyobQw22bdpyhpoTHZTTcc5umIwkHOdE7ORsWwVRR1nPxJxIpBwV7A5zp8KYIYoSAKAumCkBAOohlBk2Ww8N2ocCACgdMyUAKFXzJkoUJQAoFceUAAD10cCTZylKAFCoJs6UWOgAAKgNZkoAUKIQCx0AAPWwmhLevKo02aLUsjw3O9GbHEkVETtVxetUFDNUSSxT/iCme/tZL+xqHt/UKB5JeSdMVhahlC75jbMOJ4JWcR8sVvj8rihtqUocUwIA1MZIMyXbz0g6K6krqRMRe8YxKADA6C7V3Xe/FBEnx9APAGBcWOgAAKiPS/OTZ0PSn9t+1Pbe9RrY3mv7gO0Dy73FEW8OAJDKMdplGkadKb09Io7afrWkh2z/OCIeHmwQEfOS5iXpytlXNa9sAwAmZqSZUkQc7X89Ielbkm4ex6AAAGMQMdplCNu32v4b24dtf3Sd37/f9j/Yfrx/+XfD+tzyTMn2DkmtiDjb//5XJN271f4AAGMUkis8T8l2W9IfSXqnpCOSfmB7X0Q8tabpVyPi7tR+R9l99xpJ3+qfXDkj6U8i4n+N0B8AYJyqXehws6TDEfETSbL9p5Jul7S2KGXZclHqD+TnR7lxAECt7bR9YODn+f46AUm6TtKzA787Iumt6/Txb2z/oqS/lfQfI+LZddr81GSXhNvybINihlJNOwZHklo1COeow/0wbRX9Z5p1z/Yq2mcTNYhQqsK044uqfN2MvmknNwlFWG/ga2/xf0r6SkQs2f73kh6Q9Mub3WAN3skAAFVwxEiXIY5I2j3w8/WSjg42iIhTEbHU//ELkv7lsE4pSgBQqmpX3/1A0o22f8b2nKQ7JO0bbGB718CPvy7p0LBOSXQAgBKFKk0Jj4iO7bslPSipLen+iDho+15JByJin6T/YPvXJXUknZb0/mH9UpQAAFsSEfsl7V9z3T0D3/+epN/L6ZOiBAAFspKOC9UORQkASkVRAgDUBkUJAFALFS90qApLwgEAtTHhmZKlmQpukiSBPC3ur8pMOx1Aykv3qMHuneRnYw3GWokK379Y6AAAqA+KEgCgHi7Nj0MHAGBsmCkBQIlCjZwpUZQAoFQNXBJOUQKAQrH6DgBQHw0sSix0AADUBjMlAChRqB4nc2eiKAFAkZp5ntJki5ItzVIHUaFpvwjbRDhJmv7j0CRVPmUa+DhQIQCgVA0sSix0AADUBjMlACgRCx0AAPURUjQv0oGiBACl4pgSAABbx0wJAErEMSUAQK00cPcdRQkASkVRAgDUAzFDw1mK9nTXVriB+1iBxjFxS+m4rwYxUwKAEoWkHucpAQDqgt13AIDaoCgBAOohGnmeEokOAIDaYKYEACUKKQhkBQDURgN331GUAKBUDVzowDElAEBtMFMCgBJFcPJsE0SLSI+io5aIt0HTVPmUbeDuu0uuKAHApSIaOFMa6ZiS7Vtt/43tw7Y/Oq5BAQBG1U8JH+UyBVsuSrbbkv5I0rskvUnSnbbfNK6BAQAuPaPsvrtZ0uGI+Ikk2f5TSbdLemocAwMAjOAS/Dj06yQ9O/DzEUlvXdvI9l5JeyVp+8wrR7g5AECWSyzRYb01Iy8ryxExL2lekq7c/trmlW0AaKCQFA2cKY2y0OGIpN0DP18v6ehowwEAjEXE6kxplMsQwxa72d5m+6v93z9i+4ZhfY5SlH4g6UbbP2N7TtIdkvaN0B8AoCESF7t9QNLzEfFGSZ+R9PvD+t1yUYqIjqS7JT0o6ZCkr0XEwa32BwAYr+jFSJchfrrYLSKWJV1c7DbodkkP9L//uqR32Juf4T7SybMRsV/S/lH6AABUpNqFDimL3X7aJiI6ts9IulbSyY06nWiiw4tLx08++PR/+7s1V+/UJgNsuFK3je1qnlK3rYTten0VnZ7V8w/+7/j6zhG72W77wMDP8/3Fa1LaYrekBXGDJlqUIuJVa6+zfSAi9kxyHJNS6raxXc1T6raVul3jEBG3VnwTKYvdLrY5YntG0pWSTm/WKR9dAQDYipTFbvsk3dX//r2S/iJi8/wiAlkBANn6x4guLnZrS7o/Ig7avlfSgYjYJ+k+SX9s+7BWZ0h3DOu3DkVpfniTxip129iu5il120rdrkZYb7FbRNwz8P2ipPfl9OkhMykAACaGY0oAgNqYalEq9fOYbD9j+0e2H1+znLJxbN9v+4TtJweuu8b2Q7af7n+9eppj3IoNtusTtp/rP26P275tmmPcCtu7bX/P9iHbB21/uH99CY/ZRtvW+McNL5na7rt+RMXfSnqnVpcN/kDSnRHR+I++sP2MpD0R0fTzJ2T7FyWdk/SliPjZ/nX/VdLpiPhk/5+JqyPiP01znLk22K5PSDoXEX8wzbGNwvYuSbsi4jHbV0h6VNK7Jb1fzX/MNtq2f6uGP254yTRnSikRFZiyiHhYLz+vYDA65AGtvjE0ygbb1XgRcSwiHut/f1arEWDXqYzHbKNtQ0GmWZTWi6go5QkWkv7c9qP9z5MqzWsi4pi0+kYh6dVTHs843W37if7uvcbt4hrUT2R+s6RHVNhjtmbbpIIet0vdNItSdvxEg7w9It6i1fTcD/V3FaH+PifpDZJuknRM0qemO5yts/0KSd+Q9JGIeHHa4xmndbatmMcN0y1KxX4eU0Qc7X89IelbWt1VWZLsBYNZAAABFklEQVTj/f37F/fzn5jyeMYiIo5HRDciepK+oIY+brZntfqm/eWI+Gb/6iIes/W2rZTHDaumWZSK/Dwm2zv6B2Fle4ekX5H05OZ/1TiD0SF3SfrOFMcyNhfftPveowY+bv2PBbhP0qGI+PTArxr/mG20bSU8bnjJVE+e7S/d/O96KaLiv0xtMGNi+59qdXYkrSZm/EmTt8v2VyTdotU05uOSPi7p25K+Jul1kv5e0vsiolGLBjbYrlu0ugsoJD0j6YMXj8M0he1/Jen7kn4k6eLnFnxMq8demv6YbbRtd6rhjxteQqIDAKA2SHQAANQGRQkAUBsUJQBAbVCUAAC1QVECANQGRQkAUBsUJQBAbVCUAAC18f8Bkvc4DGHVD+kAAAAASUVORK5CYII=\n",
+      "text/plain": [
+       "<Figure size 576x432 with 2 Axes>"
+      ]
+     },
+     "metadata": {
+      "needs_background": "light"
+     },
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "plt.figure(figsize=[8,6])\n",
+    "plt.imshow(ref_bkg.value, cmap='viridis', aspect=1, origin='lower', vmin=0, vmax=3)\n",
+    "plt.colorbar()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 140,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Make a 2D array containing the PSF (oversample then bin up for more accurate PSF)\n",
+    "\n",
+    "oversample = 5\n",
+    "pixel_size_init = duet.pixel / oversample\n",
+    "\n",
+    "psf_model = duet.psf_model(pixel_size=pixel_size_init, x_size=25, y_size=25)\n",
+    "\n",
+    "psf_os = psf_model.array\n",
+    "\n",
+    "#psf_os = gaussian_psf(psf_fwhm,(25,25),pixel_size_init)\n",
+    "shape = (5, 5, 5, 5)\n",
+    "psf_array = psf_os.reshape(shape).sum(-1).sum(1)\n",
+    "\n",
+    "# Use ZOGY algorithm to create difference image\n",
+    "s_n, s_r = np.sqrt(image_rate), np.sqrt(ref_image_rate) # 2D uncertainty (sigma) - that is, noise on the background\n",
+    "sn, sr = np.mean(s_n), np.mean(s_r) # Average uncertainty (sigma)\n",
+    "dx, dy = 0.1, 0.01 # Astrometric uncertainty (sigma)\n",
+    "diff_image2, d_psf2, s_corr2 = py_zogy(image_rate_bkgsub2.value,\n",
+    "                                    ref_rate_bkgsub2.value,\n",
+    "                                    psf_array,psf_array,\n",
+    "                                    s_n.value,s_r.value,\n",
+    "                                    sn.value,sr.value,dx,dy)\n",
+    "\n",
+    "diff_image, d_psf, s_corr = py_zogy(image_rate_bkgsub.value,\n",
+    "                                    ref_rate_bkgsub.value,\n",
+    "                                    psf_array,psf_array,\n",
+    "                                    s_n.value,s_r.value,\n",
+    "                                    sn.value,sr.value,dx,dy)\n",
+    "\n",
+    "\n",
+    "diff_image *= image_rate_bkgsub.unit\n",
+    "diff_image2 *= image_rate_bkgsub2.unit"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 141,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAASwAAAD8CAYAAADNNJnuAAAABHNCSVQICAgIfAhkiAAAAAlwSFlzAAALEgAACxIB0t1+/AAAADl0RVh0U29mdHdhcmUAbWF0cGxvdGxpYiB2ZXJzaW9uIDMuMC4zLCBodHRwOi8vbWF0cGxvdGxpYi5vcmcvnQurowAAGtNJREFUeJzt3X+MZXV5x/H3M7MzuzCLuriA67p21RKtpXGxG/qDxuAP7GpskBqpNDU0Ma5JJZHENrX0D0iTJqRF1D8MyVo2YoKoKVDQokiJDcVaykIQgdVCKMrKyrIsuMuy7M7c+/SPe6fOndnv8z1zzrn33DP7eZEbZu6553u+99w7z55zvs95vubuiIi0wUTTHRARKUoBS0RaQwFLRFpDAUtEWkMBS0RaQwFLRFpDAUtEWkMBS0RaQwFLRFpjVZWVzWwb8AVgEvgnd78qev3Umhmfnjm13LaCZVGuftn1qhjWNi1Y2aON5totuV7uvZTt79D2X8l2o/cBmfcy4s/s6IsHmD16uELL8IfvnPHnDnQKvfb+h47e4e7bqmxvOUoHLDObBL4InA/sAe4zs9vc/dHUOtMzp3LWtsvKbS/44LuT6WUTwX73zPFl2S+idStsM1g+MVu+3UjuDzK5zcyfRbQfusE3L/zMqvyRlwweUX8gfi8WvZfge5uLzKn38vAdn49XLOC5Ax3++47XF3rt5IbH1lfe4DJUOSU8B3jc3Z9w92PA14AL6umWiDTFgW7B/0atyinhRuCpBb/vAX6nWndEpGmOM+vFTglHrUrAOt5B9JIDVTPbDmwHmD55XYXNicioNHH0VESVgLUH2LTg99cBTy9+kbvvAHYAzLx6k2rZiIw5x+mMadmpKtew7gPONLM3mNk08BHgtnq6JSJN6uKFHqNW+gjL3efM7FLgDnppDTvd/ZFoHfP0yFF3Kt6ezcXtppQdQew1XHJZJPcZRyNZwXuJRuRyyo5yVRLsv2jEM9efaB9Fuz7aZifzz3rZfV9pNHmZzy+HA50GglERlfKw3P124Paa+iIiY6KJo6ciKgUsEVl5HJgd02tYClgiMsDxlXlKKCIrkENnPOOVApaIDOpluo8nBSwRWcTolB4GHy4FLBEZ0LvoroCFWzrnZyLIs4JMFYNg3SjHKFvhIEzcyaybkKuMEOWb5XLVkm3mju+j3K9gH/lE/KWemEs3HFaeiHKpKqQ6h9+hIVWI6EynV56cjXZ83G7qMy1beWPxpus6wjKzNcDdwGp68eaf3f2Ksu3pCEtElujWd4R1FHiXu79oZlPAPWb2bXf/rzKNKWCJyIA6j7Dc3YEX+79O9R+ljwNVIllEBjhGh4lCjyLMbNLMHgT2AXe6+71l+6aAJSJLdN0KPYD1ZrZrwWP74rbcvePuW+hVdDnHzM4q2y+dEorIAMc4FtZvHrDf3bcWatf9BTP7d2Ab8HCZvukIS0QG9BJHJwo9cszsNDN7Vf/nk4D3AD8u27eRH2Glhl2j9AOIUxfCofeSE0lUEQ6952ZgicrhBKkAYbmWzPXT8kP6ubH3YM3C/4AXbxOGk/6SK2kTfY+i1I4mvptF1Zg4ugG4vj9pzQTwDXf/VtnGdEooIgPcjU6VhLeBtvwh4OxaGkMBS0SOo6tbc0SkDXoX3cczNIxnr0SkMfMX3ceRApaILNHRzc8i0gbzme7jaPQBKzFcGw7Zk5lJJRpWrnIXfrS8ZCWHXOWEsL8l0zdyyq6bm3WobIpBlQGqsjPRRKkL3VXxDrJuuRyEKjMdJb+bNR0YdWsaJaybjrBEZEDv5mcFLBFpAceYLZ3ZO1wKWCIywJ3aEkfrpoAlIouYEkdFpB0cHWGJSIvooju99IPUUHiuWkMY8DPD66XapMIQeTS3QOZaZmcyfSgeDZ+XTYfotVty3cxofrfke4lUSd8om0oRVVzICb8LFSpspFIt6sj3dKzOmu61qhSwzOxJ4BC9kDFXtJCXiIyv3jRf43nyVUev3unu+2toR0TGgiZSFZGWcMY3071qrxz4rpndf7zi8wBmtn2+QP3s0cMVNycio9DpH2XlHqNW9QjrXHd/2sxOB+40sx+7+90LX+DuO4AdAGtP3dRw4VcRyXG3sT3CqhSw3P3p/v/3mdktwDn0pqUWkZbqXXQfz1tzSodRM5sxs1PmfwbeS8mpe0RknPRquhd5jFqVI6wzgFvMbL6dr7r7d6IV3KCbCNxVcoWiXJfU9nLrFelTGdnyMh7VpglWrFDSJky5qXASPzlbf65VlZIsUa5fmFeX238lcwRL578R5IbVcNGld9F9hY0SuvsTwNtq7IuIjAlluotIK6zYTHcRWZk0CYWItII7zHYVsESkBXqnhApYItISupeQ3qh8KpUgGs2HzNB7VBqkQtmVsjPuhLPbZPb45LFy7Ubfr2zKSFSep0q7ZcvzVBjub0KY9hClaJQsPTNsKzKtQURWKp0SikiLqKa7iLRCb5RwPO8lVMASkQFKHBWRVtEpoYi0gkYJ5znJu8knZ+NVozvtw0oOFYbIw/SEkhUFchUi5laX+6KUnYUGiIsMVajkEO6/ksuqVGuoUtGidLslP5YqKSN10CihiLSCuzGngCUibTGup4TjGUZFpDHz17CKPHLMbJOZfc/MdpvZI2b2qSp90xGWiCxR4xHWHPBpd3+gX1L9fjO7090fLdOYApaIDKgzD8vd9wJ7+z8fMrPdwEZAAUtE6jGMPCwz2wycDdxbto2RBiw3SM4eVGGYNvrHoDuVXpYdGg7anZiL2k2PZXdXlf8iRO1OHksvy73P7lS6T9EdGpNH4zH7qNrFy69KXz5d9XK63ezgVck5PMImMytGi6P9F32HJjJpPsOchcsd5ooX8FtvZrsW/L6jPxfpADNbC9wEXObuB8v2TUdYIrLEMk4J97v71ugFZjZFL1jd4O43V+mXApaIDKjzGpb15gG8Dtjt7tdUbU9pDSKyhLsVehRwLvBR4F1m9mD/8f6y/dIRlogsUddFd3e/h/KXD5dQwBKRAe7jm+mugCUiixgdTfMlIm1R8PrUyGUDlpntBD4A7HP3s/rPnQp8HdgMPAlc5O7PZ9sinROU3T9Bfk2U79OpUKokLGlT8vPMbXPqSPoFx2bSb8Yn0x2amIvzpaIcrignqhPkbwEcOTXd36nDQbtBiZ3pQ/EOnDspmuYnvajszDc5Ua5VtP8mZ+PPLDXTUdlyNguNcz2sIsd9Xwa2LXruM8Bd7n4mcFf/dxFZCbx3HavIY9SyAcvd7wYOLHr6AuD6/s/XAx+suV8i0qAuVugxamWvYZ3Rv6kRd99rZqenXmhm24HtANMnryu5OREZFR/ji+5D75W773D3re6+dWrNzLA3JyI1aO0pYcIzZrYBoP//ffV1SUSaVmOme63KBqzbgEv6P18C3FpPd0Skab2jp/EMWEXSGm4EzqNXRmIPcAVwFfANM/sY8DPgw1U7khuOjfZN2RlsciU6oj5Zp1wJmamX4mH52SB1YXUwpH9kXXq9NQfibXrwLTi2Nt1umEIATB9K76OJYNg++lyys8kEKS7RNeLOdPCZHc6kUqwpl0oxEXyHcu+zm0hjqWvuiHFNa8gGLHe/OLHo3TX3RUTGRBPXp4pQpruIDHCM7piOEipgicgSY3qApYAlIot4i+8lFJET0JgeYilgicgSOsLKyA3HRjO0lJ2JJrdeVBkgGu6Phs/DYXdgZu+x5LKJY+n+TMxOJ5c9dX68c1/zg/Sy2ZPTb2ZuJt5/hzanl23+5kvJZc+/JX1HxGxmm6tfqH/anGhWIcikzgS7PqrkkE25Sc2gVFe1hq4Cloi0gVOg3lMzFLBEZAnlYYlIeyhgiUg7NHOfYBEKWCKylI6wRKQVHFyjhP3h0sRwbTTEC3FlgNLDyplC/9Fw9uqD6fyE6YPpN/PT960Ot7nh++llq4IJKk76xZHkss3fTKc8AKy5/4nksl/8yVuSyzZ+59mw3X3nrk8ui1IXos8lqqoA8ecdLguazX1PokkzwtSZoBzIxGy4ScikPVSngCUibaFTQhFpDQUsEWkFJY6KSJsocVRE2kOjhCLSFnVMeT8MClgiMsjRRfd5qZypXDmNKE9rLsiDiWapmVsTl12ZmEuv6xPpbR7ekM57euVj4SZ57jfTH8lEuvIMr716V3LZmjf/erzNP0rnWr3wW+l9sP6HJ4ftnvbVHyaXHfjQ25LLDr4x/bmsfyhO2Itypo6+Kv0li2awifKsctuM/vCjHC2fzE0jFS+uxnTRXURaREdYItIa8VSMjVHAEpFBysMSkTYZ11HC8ZwtUUSa5QUfGWa208z2mdnDdXRLAUtEhunLwLa6GsueEprZTuADwD53P6v/3JXAx4H5+iKXu/vt2bZIH2rmgnVUQiYyO5OOybmZeng5vSgayj52errhXHmUTf+YTk944aK3J5ft+ZvfT7d558Fwm/dedW1y2Vv/88+Sy5797VeE7R59z5bksrVPpfefBZkLndWZVJTZdNmfaAagtU+nN/rihvjPZHWU1hCVrZmrMMPPkC8x1XVK6O53m9nmelordoT1ZY4fIT/n7lv6j2ywEpGWcHq35hR5wHoz27XgsX2YXcseYdUdIUWkBYofYe13961D7MmAKtewLjWzh/oX1dbV1iMRaZx5sceolQ1Y1wJvArYAe4HPpl5oZtvnDxdnXz5ccnMiMlI1jRLWrVTAcvdn3L3j7l3gS8A5wWt3uPtWd986tSZdx1tExkh9aQ03Aj8A3mxme8zsY1W6VSpx1Mw2uPve/q8XArXkWIhI8+o83XP3i+tpqadIWsONwHn0RgP2AFcA55nZFnox9kngE0U2ViXjvxv0dPpwVJEhvcHszCSBl05P3/m/5kC6P6985Pmw3b3b09cvD21Of4u6JwfD+a+IZ+rZctVfJJcFEwfx0hnxt3rm5+llJ+1P99dSUysBJ+0LSlYAh18bzxCU8tJp6S/Y1JH4fc6dlD5RsaAKRHR+M3k0M1NPJj2msrYW8EtEyOuG0BcRGRPjemuO7iUUkaUUsESkFRpKWShCAUtEllLAEpG2KHvv7rCpWoOItIaOsERkKZ0SxnKHoHMnBXkhUZWOdLpPmNsFMNEJZuM5nN5olJfz3NZXh9uceSbd4Vf+b3onHXx98GYyKTWnPno0ueynlwQ5Zd9fE7a75vn0PjqyPp1rFX0Xjpw2FW4zKhm0+mAwM06QvtWdjHdgtM1otqfou5nLs/JUn+pIn9JFdxFpFQUsEWkNBSwRaQNjfEcJFbBEZJCuYYlIqyhgiUhrKGD1JYZdu/FoNVNBCZnofLsb1EepMlNPVDYkKmlz0nPBWDbw4sb0cP/qYHj9lD3pdn/5xrjkymQ6q4Fvv+Pq5LIP/fCvwnZX/zK9j7IzFiXkhvujkkFzq4M0lSPpDzvX107w3S2bujARlaUBLDXjTk2BRqeEItIeClgi0gquUUIRaRMdYYlIW+galoi0hwKWiLRCQ3MOFjHSgBWm/GdzDNJDwJ1gUphoSLoTTQkDWDe4u//kaKaUdJuza+Mx8lVH0ss8nfHAsVPS7U69WP7b96d/95fJZWuDVADIpYUEyyr8sUSpAlMvpTsUrdddFX9PVr1crt2JVGoCMBFnv4SpFFUZOiUUkRZRwBKR9lDAEpHWUMASkVZQtQYRaRUFLBFpi9bemmNmm4CvAK8BusAOd/+CmZ0KfB3YDDwJXOTuz0dtOek0g+wd8cGQftnh81WZO+KjSg+TR0v+E5RZLUqliCY06JbcPxBPxrHq5Wjihni4P9pHk7NBu8F+n8jsv2ibcXWEdJvm5b8n0WcWTRiRS1sY9inbuJ4SFinyMQd82t1/A/hd4JNm9lbgM8Bd7n4mcFf/dxFpO1/GY8SyAcvd97r7A/2fDwG7gY3ABcD1/ZddD3xwWJ0UkREb04C1rGtYZrYZOBu4FzjD3fdCL6iZ2em1905ERm5FZLqb2VrgJuAydz9owa0yi9bbDmwHmD55XZk+isiIRddSm1SoUK2ZTdELVje4+839p58xsw395RuAfcdb1913uPtWd9+6as1MHX0WkWFq8zUs6x1KXQfsdvdrFiy6Dbik//MlwK31d09EmmBe7DFqRY6wzgU+CrzLzB7sP94PXAWcb2aPAef3fxeRlaDGIywz22ZmPzGzx82sUjZB9hqWu99DOmPk3cveYupN5vKTyqY9BSE512ZU/iPKoRnWoXInmPym7OwsEJdHicr65K5zdIJZaiaPlcvR6gYzB/WU2/nhzDeZPLZo30ezQUXt5srLRLlzdajr6MnMJoEv0juo2QPcZ2a3ufujZdorOdmSiKxo9R1hnQM87u5PuPsx4Gv0UqJKUcASkUH9WXOKPArYCDy14Pc9/edK0b2EIjJgmXlY681s14Lfd7j7jkXNLVb6hFMBS0SWytw/ucB+d98aLN8DbFrw++uAp8t2S6eEIrJEjWkN9wFnmtkbzGwa+Ai9lKhSdIQlIoNqTAp19zkzuxS4A5gEdrr7I2XbG3nASs78kktrCIZ5o9QFD4bBLUpbyLQbif7lybVZdjYZD0b7s7dZRDMSRcPyuVIvQepC1N8oZSRKeci1G81+E6awZIQpBmWbzaXczB7/+drSEWqsh+XutwO319GWjrBEZInWFvATkROMs5yL7iOlgCUiS7S+vIyInEAUsESkDVZEAT8ROUG4j20Bv5EGLCMzi0ig/F3v6R2f+1fESvY1rOSQEc1+Ex2ml037gPKpC2FqApnZjIZQfSMn/COs8JlFlRXCzzOQTX9JvZUK72OwAzW1UzMdYYnIEjolFJF2cECnhCLSGuMZrxSwRGQpnRKKSGtolFBE2qGhKbyKaE3ACm/GjHZuMMybG5aP1o36Ew5J51IpSrbr0SdZYd6GaJtlU1QgrnAQpkNkJmdIVgMBJhMVDqBaukSUuhB+b6ukIJSczKWIXuLoeEas1gQsERkhVWsQkbbQEZaItIOuYYlIe+heQhFpE50SikgruEoki0ibtPUIy8w2AV8BXkNvsHOHu3/BzK4EPg4823/p5f3ZMZKcIN8lt3+GNPtIKJqBJSjJEpaByfQnzAcqmbczeaz8NjvT6Y16hfs3ohyuKK9pIrPJbvReSpYoyr3NqLxMPJtRsF4mLyyVb5bNLSxqPONVoSOsOeDT7v6AmZ0C3G9md/aXfc7drx5e90SkCdYdz3PCbMBy973A3v7Ph8xsN7Bx2B0TkYY4Y5s4uqwbEsxsM3A2cG//qUvN7CEz22lm6xLrbDezXWa2a+7lw5U6KyLDZzjmxR6jVjhgmdla4CbgMnc/CFwLvAnYQu8I7LPHW8/dd7j7VnffumrNTA1dFpGhcy/2GLFCo4RmNkUvWN3g7jcDuPszC5Z/CfjWUHooIqM3pqOE2SMsMzPgOmC3u1+z4PkNC152IfBw/d0TkZGbv4ZV5DFiRY6wzgU+CvzIzB7sP3c5cLGZbaH39p4EPlFoiyVn+wiHh6M0ggpDx+FQd9Ru9F5yM81E/7CVfJ/RcD7EKQaTx9IbHdb+I0hryM1CE6VwzK1O7/yJufIz6nSm0i+IbnGJPupc6Z7U96SuSqFtHiW8h+N/ZGHOlYi0VTPXp4pQpruIDHIUsESkRcbzjFABS0SWUgE/EWkPBSwRaQV36IznOeHIA1ZqKDy64733grIbDJrMDB1HM7uUnamnSp2hMF2iZMpD7wVBs8F+r/JewooMwecSzYoD5VMXylbfAJicDVIXSlZPyL3P5KQ5tVVr0BGWiLTFmAasCrOxiciK5EDXiz0qMLMPm9kjZtY1s61F1lHAEpFFHLxb7FHNw8AfA3cXXUGnhCIyyBnJRXd33w3Qu125GAUsEVlqTK9hKWCJyFLFA9Z6M9u14Pcd7r5j/hcz+zd680Es9rfufutyuzXygJUcCq8wOYPlUiISOtPl1oPM0HvJ9APIV0Coe73cuqWrUhBXDgi3WSFFYzKqjhD0N5fiEoneS9kqI7nvSXdVouFa0hqWdfPzfndPXjB39/fU0aN5OsISkUEOjGl5GY0SishSIyiRbGYXmtke4PeAfzWzO3Lr6AhLRBYZza057n4LcMty1lHAEpFBDl49x2ooFLBEZKmKWezDooAlIkspD0tEWsF9bEcJRx+wEnkiVWZgiYRlOjL/iEQlb4ZVNiR6n7kZY5JtZt5n2Vyr3HuJyuyGOVrBNrvBDDUQz/ITvs+S+zan7PvMfWap91ml5M8AHWGJSDs43imZjT1kClgiMmi+vMwYUsASkaWU1iAibeCA6whLRFrBXUdYItIe43rR3XyEw5dm9izw0wVPrQf2j6wDeepPbNz6A+PXp6b782vuflqVBszsO/TeRxH73X1ble0tx0gD1pKNm+2KaumMmvoTG7f+wPj1adz6s9KovIyItIYCloi0RtMBa0f+JSOl/sTGrT8wfn0at/6sKI1ewxIRWY6mj7BERAprJGCZ2TYz+4mZPW5mn2miD4v686SZ/cjMHlw0ZdEo+7DTzPaZ2cMLnjvVzO40s8f6/1/XcH+uNLOf9/fTg2b2/hH2Z5OZfc/MdvenN/9U//lG9lHQn8b20Ylg5KeEZjYJ/A9wPrAHuA+42N0fHWlHBvv0JLDV3RvLnzGzdwAvAl9x97P6z/0DcMDdr+oH9nXu/tcN9udK4EV3v3oUfVjUnw3ABnd/wMxOAe4HPgj8OQ3so6A/F9HQPjoRNHGEdQ7wuLs/4e7HgK8BFzTQj7Hi7ncDBxY9fQFwff/n6+n9QTTZn8a4+153f6D/8yFgN7CRhvZR0B8ZoiYC1kbgqQW/76H5D9qB75rZ/Wa2veG+LHSGu++F3h8IcHrD/QG41Mwe6p8yjuwUdSEz2wycDdzLGOyjRf2BMdhHK1UTAet4dRabHqo8193fDrwP+GT/dEiWuhZ4E7AF2At8dtQdMLO1wE3AZe5+cNTbL9CfxvfRStZEwNoDbFrw++uApxvox/9z96f7/99Hb560c5rszwLP9K+VzF8z2ddkZ9z9GXfveG8OqC8x4v1kZlP0gsMN7n5z/+nG9tHx+tP0PlrpmghY9wFnmtkbzGwa+AhwWwP9AMDMZvoXTTGzGeC9wMPxWiNzG3BJ/+dLgFsb7Mt8QJh3ISPcT2ZmwHXAbne/ZsGiRvZRqj9N7qMTQSOJo/2h3s8Dk8BOd//7kXfiV315I7+afXYV8NUm+mNmNwLn0btL/hngCuBfgG8Arwd+BnzY3UdyITzRn/Poneo48CTwifnrRyPozx8A/wH8iF9Nb3E5vetGI99HQX8upqF9dCJQpruItIYy3UWkNRSwRKQ1FLBEpDUUsESkNRSwRKQ1FLBEpDUUsESkNRSwRKQ1/g98TO4zyvcgrgAAAABJRU5ErkJggg==\n",
+      "text/plain": [
+       "<Figure size 432x288 with 2 Axes>"
+      ]
+     },
+     "metadata": {
+      "needs_background": "light"
+     },
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "plt.imshow(diff_image.value)\n",
+    "plt.colorbar()\n",
+    "plt.show()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 142,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAASwAAAD8CAYAAADNNJnuAAAABHNCSVQICAgIfAhkiAAAAAlwSFlzAAALEgAACxIB0t1+/AAAADl0RVh0U29mdHdhcmUAbWF0cGxvdGxpYiB2ZXJzaW9uIDMuMC4zLCBodHRwOi8vbWF0cGxvdGxpYi5vcmcvnQurowAAHKNJREFUeJzt3W+MZGd15/Hvqeq/0zNjzzDYjMcDQ8BCICvY2ZGTXaOVk0BiEJEhWRCWAo6EMkgbS2GFlEXOC3gTyWQDXl5EaIfYwkjEBAUTvFknxkFZOeSP47HlYMMkG8vymokHD+OxPX/7T1WdvKga6Orq5zzVt27Xrdvz+1glT/fT996nbt0+fe99zj2PuTsiInXQqLoDIiLDUsASkdpQwBKR2lDAEpHaUMASkdpQwBKR2lDAEpHaUMASkdpQwBKR2pgaZWEzuxn4PNAE/sjd7ww3Nr/gMzt2F9tYlJBvm7DcKDZrm1vpoYSin9lWsgn7YPnMKVqL50Y6sn/55xf8pVPtoX728e8uPeTuN4+yvY0oHLDMrAn8IfAu4BjwmJk94O7fTy0zs2M3b/m1/1Zse510Wyd4Fxbsdx/h/NKCAyrqa26bUXtjJepQsM7M4Ru9l0h2vdG+jz6zYP+NJHif0X6P3geAN4Nlo2MhWC4XsFKf2T/ff1e84BBeOtXmHx96/VA/29z7r3tG3uAGjHJJeAPwjLs/6+7LwFeBW8rplohUxYHOkP+N2yiXhPuAH6z6+hjws6N1R0Sq5jgrPtwl4biNErDWuyAYOFE1s0PAIYDp7btG2JyIjEsVZ0/DGCVgHQP2r/r6auCFtT/k7oeBwwDbrth/qdxOFaktx2lPaNmpUe5hPQZcY2ZvNLMZ4EPAA+V0S0Sq1MGHeo1b4TMsd2+Z2e3AQ3TTGu5x9+/FC6VHXDrT8fbCkaOioz+jnPUWHTjOfcbReyk4GpV7n9Eoa2OTbmWEI4xBW+69hKOwBbeZOzaL7qNwBHGzUm6G4EB7QnNLRsrDcvcHgQdL6ouITIgqzp6GMVLAEpGtx4GVCb2HpYAlIn0c35qXhCKyBTm0JzNeKWCJSL9upvtkUsASkTWM9qZVBhiNApaI9OnedFfAAkvnEoWVCIjza5rL6bYoxygnrGJQsC1XGSGqDBDmA0W5SwWf/Id4v49SBSL8vDerSlu0j1pB2wi/u2GOW7APcttM5XCVEWa6eVgKWCJSE52SzrDMbA54BJilG2/+1N0/VXR9Clgi0qfkM6wl4Bfc/ayZTQPfMbO/cPd/KLIyBSwR6eMY7ZKuy93dgbO9L6d7r8JJE6rpLiIDOm5DvYA9ZnZk1evQ2nWZWdPMngROAA+7+6NF+6UzLBHp4xjLYf3mPifd/WC4Pvc2cJ2ZXQ58w8yudfeni/RNZ1gi0qebONoY6rWh9bq/AvxfoPCkFeM9wwrKy+QmZ2gEw87RgEbh1IRh2pMbLbgccQmZKH2jaLkWiIf0w2VH+XNXwUxHjWj/Rb8JmbTv6BiLPrNQLhUl1aeSHqkp66a7mb0WWHH3V8xsHngn8Jmi69MloYj0cTfao0wp1W8vcG9vlq0G8DV3//OiK1PAEpEBnZLOsNz9u8D1pawMBSwRWaN7030yQ8Nk9kpEKnPxpvskUsASkQFtPfwsInVQZqZ72cYasCxIaxilWkMjGnYOqh+UNxCydsXpplFm6gnTN6Llim8yXDj7mQUpGtGyo3wu4XlBwWoN2ds5mzBrzkgzOpWgs2m/HKPRGZaI9Ok+/KyAJSI14Bgrwz+aM1YKWCLSx50yE0dLpYAlImtYaYmjZVPAEpE+js6wRKRGdNMdwKG5sv44eWcqV1IgaIpSF0YY74+Glov+AcotF7UXHgbPbLPo+8xNbhE2R59n9F5yVypRGkYwO6g3ghUXTFsAsE6wzWimicz7TE5uUcKVnGOl1XQv20gBy8yeA87Q/UhbuUJeIjL5utN8TebFVxm9+nl3P1nCekRkImgiVRGpCWdyM91H7ZUD3zKzx9crPg9gZocuFqhvLZ0bcXMiMg7t3llW7jVuo55h3ejuL5jZFcDDZvbP7v7I6h9w98PAYYCF1+wvqYCriGwWd5vYM6yRApa7v9D7/wkz+wZwA91ZXkWkpro33Sfz0ZzCYdTMFsxsx8V/A78EFJq6R0QmSbem+zCvcRvlDOtKunOMXVzPH7v7X2aXSl0UZi4Wo3IkUa4LzfR1dpS/BZszG082d6ng7Ddh7tIIF+KjlEApOmNMtA8areLJXx4cC2G+We44iZYNloveSy4WNFN9KqEsTfem+xYbJXT3Z4G3l9gXEZkQynQXkVrYspnuIrI1aRIKEakFd1jpKGCJSA10LwkVsESkJvQsId0h3kZyiDhX66XYNhuJcjYQz+oCmRSEoD+dgsPnAM3l9Eaj9YYyi4VlV4ISKLn3UrRsTdSfrDD1I8p5CNJfouWIjulYtFw2O2ET48mWTGsQka1Kl4QiUiOq6S4itdAdJZzMZwkVsESkjxJHRaRWdEkoIrWgUcKLPD3U3cwMZUez6oQVBYLVdjKfSdHPLFtRINCeKbjRzSqNWLRCRG610ecSpG9kUx6iShnRcRJ1KJdxU3SbBauMROstK8xolFBEasHdaClgiUhd6JJQRGphku9hTeZ5n4hUquM21CvHzPab2V+b2VEz+56Z/fYo/dIZloj0KTkPqwV8wt2f6M0B8biZPezu3y+yMgUsERlQVh6Wux8Hjvf+fcbMjgL7gBoELEs/pW+ZHIPc5A0pneAdZoflCw7ph0P2mT1edBg8nPDBMykj08UqMkSVJSBOQVi8LL3iqcUoTyDcZGFhZYkRthl93tHEKrl9m5xQo4T0FndoDV/Ab4+ZHVn19eHeXKQDzOwAcD3waNG+6QxLRAZs4JLwpLsfzP2QmW0Hvg583N1PF+2XApaI9Cn7WUIzm6YbrL7i7vePsi4FLBEZ4CUFLOtOXHo3cNTdPzfq+pTWICIDOthQryHcCHwY+AUze7L3ek/RfukMS0T6uJeXOOru36HEoRIFLBFZw2hrmi8RqYuy7mGVLRuwzOwe4L3ACXe/tve93cCfAAeA54APuvvL2a05WCI3xxu5Wi/ppijfpx2sN9WXH28yyE+KF0yv19rxOqeX0wlBywvpv3o+l16nZWZ1iXJ+ps+n+9Oeif8KL16ebp8+F3xms+l9NHs6Tp5bmQ8+74JlYHIXNOF6g2Msyn+LZnvKrXdUdX+W8EvAzWu+90ng2+5+DfDt3tcishV492/uMK9xywYsd38EOLXm27cA9/b+fS/wvpL7JSIVKnGUsFRF72Fd2XtGCHc/bmZXpH7QzA4BhwBmtl1ecHMiMi4+wTfdN71X7n7Y3Q+6+8Hp2e2bvTkRKUFtLwkTXjSzvQC9/58or0siUjV3G+o1bkUD1gPAbb1/3wZ8s5zuiEjVumdPkxmwhklruA+4iW4ZiWPAp4A7ga+Z2UeB54EPDL1FK/gmg8WilIi41MsmpVIEw9VRmgDASpC6MHsmveyFXenlFk7F2/TgKFjenl5vK0ghAJg5E5XDSbdFJW1ycyM0ghSO6PcrSqWYORvvv2jZ6MANS9pkZs3pTCeWKymGTGpaQzZgufutiaZfLLkvIjIhqrg/NQxluotIH8foTOgooQKWiAyY0BMsBSwRWcNr/CyhiFyCJvQUSwFLRAboDIvukGunmWjM7J9oGDxKT4j2e/S0PMTD2dFwfyRXOWHheHr6m0ZQyaGxPJNsO/bOuK9X/n26LUpdWFmI99+ZN6TbDjxwLtn28lvTT0Rc2B5vc+7lgjPuFEx5gPgYi9IwGq1gudTvyRg40MnMYlUVnWGJSD+nvISukilgicgA5WGJSH0oYIlIPVTznOAwFLBEZJDOsESkFhxco4SAQXtm/R0RVT+AOI0gfOo92O+5bbaiJ/iDygkzr6bHq5+/OZ1+ALD379JtU2fTORHzPzyfbDvwv2fDbc4+/kyy7cUPvi3Ztu8v4jJoJ97x2mRblLrQDCZgyKUYJNNmiFMFovSDcIKKTJ9SVRUAOsFvX6OVmSAlVaGktDijgCUidaFLQhGpDQUsEakFJY6KSJ0ocVRE6kOjhCJSF9FcCFVSwBKRfo5uukOvvEwiLyVX6iXKhWnNpdum01VMaM3F25y6EJS0Cfp79up0rtWOZ8NNcvLa9EfSXEq3XfU/Hk+2zb7lzeE2X/qVdK7Vyz+d3vGveWohXO9r7/unZNup//L2ZNsrb04nRe15Oq7P0whyuBZ3pROxojyslW3xcRLmTAU3rztBSl5uRqfkGVApV3Kmm+4iUiM6wxKR2shk91dFAUtE+ikPS0TqZFJHCSdztkQRqZYP+cows3vM7ISZPV1GtxSwRGQzfQm4uayVZS8Jzewe4L3ACXe/tve9TwO/Cfyo92N3uPuD2a0FaQ3Jchk90dBxJ1GyBmAxrqwSima4iUqgLO4KZvHJzIbyhruCVIBf++lk27E7/lOybf+3TofbfPQzX0i2ve3vfj3Z9qP/sDNc7+K7rku2bT+W3n9RCstKMIsPQFDNhaXL0ssu/DD9YZ+9Kv7QZs6k29oFj7/c70Pq7KasW09lXRK6+yNmdqCctQ13hvUl1o+Qd7n7db1XPliJSD043UdzhnmNWTZgufsjwKkx9EVEJsXw97D2mNmRVa9Dm9mtUUYJbzezjwBHgE+4+8sl9UlEKraBS8KT7n5wE7vSp+hN9y8AbwKuA44Dn039oJkduhh9WxeC52REZHKUNEpYtkIBy91fdPe2u3eALwI3BD972N0PuvvBqfn42TMRmRDlpTXcB/w98BYzO2ZmHx2lW4UuCc1sr7sf7335fqCUHAsRqZ55qaOEt5azpq5h0hruA26ie3PtGPAp4CYzu45ujH0O+NgwG/MGrCwUG1mwYLy2uZRerhMMKzcX421GT9OfvTx9cjrzavrT3v302XCb//axdBWDc69Pj/d35tLD8suXx2Prb//Mf022RUU0zu+Nj+ptL6QXnns5/V68md63cy/H1RrOXJ0+pKMZbM7uS6cu5GbNWdydfp/RL344o9NKvM3UsRlVndiQuhbwS0TIuzehLyIyISb10Rw9SygigxSwRKQWSryHVTYFLBEZpIAlInWRG2ioiqo1iEht6AxLRAbpkrCbI9JKJLtHpVwA2nPpPdi8kM4ZaQTrjfJyAJpLQX5NK73c8s70cidu2BFuc+6l9Pvc+Xy67exV6Y/Sp+Kjb/e/pJN+fvCRdNuOv90WrnfmdHq7564MTu6DFKBzr4sP2fZssXy91ny6zTO/JdFxFB3XUR5W6vfkx8s219+3ufJFQ9FNdxGpFQUsEakNBSwRqQNjckcJFbBEpJ/uYYlIrShgiUhtKGB1h1xbC4nh2Ew1i2hI2oNh5VZQImaU6/TEqDIQz5QSlZ4BuHBlekd0XkqnAiz8MP1mXnlznL/RvJDu09+8465k2zuf+p1wvVPn022doG5NVCIll4oSHUcr29NtUTmXXMmW9kyx3+6o9FHRgDFps+aUTWdYIjJIAUtEasE1SigidaIzLBGpC93DEpH6UMASkVqoaM7BYYw3YDWc1vb1H1+PZsUB8GgYPDh/HeXm4dTZ9DajIfKoesTSrvh9RlUgokoES8HQ+9T5zNEXNL/nznTqwvxSvN4wHSDYDVHFgdywfZRSElVOWNmZfi/tuXib0THWmg/20QjXXZ5KpYjybYZk6JJQRGpEAUtE6kMBS0RqQwFLRGpB1RpEpFYUsESkLmr7aI6Z7Qe+DLwO6ACH3f3zZrYb+BPgAPAc8EF3fzlcWdNp7Fz/sXjLDFd7sAN9KT0O7ivpsXVbjh/Db+1I/5mZOhekWUTD8rk9XvAvWyfYZiN38AXLNlei4f5MikY7eDNBUyeosDFKNYIodSHaf51MNYbOXLCDo2urYHKQxkw8K0tyN5SQ1gCTe0k4zLyELeAT7v5W4OeA3zKztwGfBL7t7tcA3+59LSJ15xt4jVk2YLn7cXd/ovfvM8BRYB9wC3Bv78fuBd63WZ0UkTGb0IC1oXtYZnYAuB54FLjS3Y9DN6iZ2RWl905Exm5LZLqb2Xbg68DH3f205W46/WS5Q8AhgOaey4r0UUTGzDqTGbGGuYeFmU3TDVZfcff7e99+0cz29tr3AifWW9bdD7v7QXc/2NyRmc5WRKpX53tY1j2Vuhs46u6fW9X0AHBb79+3Ad8sv3siUgXz4V7jNswl4Y3Ah4GnzOzJ3vfuAO4EvmZmHwWeBz6wOV0UkbGbzCvCfMBy9++QTvv4xY1srNFwti2sP/2NZcJ1q5VOlGlNp3NW2sFyncUg+QYgyO9qzacXawa396yTyV2KSpVsS7dNLabX2858ylH5mSjvKcyzAloLUQ2ZuE8puVIvnekg12o2yCmbD3Z8sE4AptLLzmxLT8fTaARlkTK/D9NT6x/z0To3osyzJzO7Gfg83Yy/P3L3O4uua6h7WCJyiSnpHpaZNYE/BN4NvA24tZfHWYgCloj0682aM8xrCDcAz7j7s+6+DHyVbg5nIQpYItLnYh5WSTfd9wE/WPX1sd73CtHDzyIyyIe+ibXHzI6s+vqwux9e9fV6NzIL3yFTwBKRARu46X7S3Q8G7ceA/au+vhp4oWC3dEkoImuUmzj6GHCNmb3RzGaAD9HN4SxkrGdY0802V+08vW5bK5xiBc4spadDabXTy7Y66bbzjWCKFaAdlOrwRjrlwYJttjM3KptBekKkE3yS0WwxuWU7U1FeQ7zeaLvR7DbtoLxM7k9/ZzpY70Kw84PUhOZ8vAPn5peTbbPT6bSGmURqwjCaif3QzNYSGk5Z9bDcvWVmtwMP0U1ruMfdv1d0fbokFJEBZRbwc/cHgQfLWJcCloj0czZy032sFLBEZEDty8uIyCVEAUtE6mBLFPATkUuE+8QW8BtrwJpqdNg1d37dtij9AOA1c+eSba8upUsnnF1Jj5G3g3QIgMWgskInmHEnmmXFWplcgKCigLXTyzaCEfJoFh+A9mx6vdFf2mimmdx2wyyWoC1brSGawWY6Sl1oJdvm5tKpCQDbZtNpDZfNLSbb5qeClIdGuj+RoyWlNeiSUERqQ5eEIlIPDuiSUERqYzLjlQKWiAzSJaGI1IZGCUWkHiqawmsY463WYG1eN7d+tYZONNsBsBSUFGgE56/R0+vtTCpF5EKQYhB91p1MWkMjWG9YiSDYaCMelQ+FH0vmoI6W7QQVGdpBWohnJlnwYMIIC6pvTAcTmURpCwB7tqVTbnbOpNMaLpu+kGybLZjWMB3ltwypmzg6mRFLZ1giMqjEag1lUsASkQE6wxKRetA9LBGpDz1LKCJ1oktCEakFL7dEcpkUsERkUF3PsMxsP/Bl4HV0BzsPu/vnzezTwG8CP+r96B29YvNJM402r589tW7bSqYGyvkgcWc6+HPQCO4e5vKwotwwD9oWPT0ljAdlaSCTpxXcV2gEy+VmzYlusEa5X7m/wtGy0TY9OCqjNgCbS7/ZmW3pfKr5INdqx+xSuM3t0+n2PTNBjtZUOg/rsqANoJHY+UXL0gyYzHg11BlWC/iEuz9hZjuAx83s4V7bXe7+B5vXPRGpgnUm85owG7Dc/ThwvPfvM2Z2FNi32R0TkYo4E5s4uqFnU8zsAHA98GjvW7eb2XfN7B4z25VY5pCZHTGzI2dPxY84iEj1DMd8uNe4DR2wzGw78HXg4+5+GvgC8CbgOrpnYJ9dbzl3P+zuB9394Pbd0ZS+IjIx3Id7jdlQo4RmNk03WH3F3e8HcPcXV7V/EfjzTemhiIzfhI4SZs+wzMyAu4Gj7v65Vd/fu+rH3g88XX73RGTsLt7DGuY1ZsOcYd0IfBh4ysye7H3vDuBWM7uO7tt7DvhYfmNt9kwlystkYudiMEY+HYzbrwTTs7TCqVvgXDDjTiMqcxK0ReVPAHwpaLcg5SFYrJ3OsgCgGYzaR6VpohIxWdFbCcrAdGYzvyXBfpifTb+Z2el0OsCOIG0B4Kr5V5Ntu6bWnyUKYM/0mWRbs2A0KLrcWnUeJfwO6x9eYc6ViNRVNfenhqFMdxHp5yhgiUiNTOYVoQKWiAxSAT8RqQ8FLBGpBXdoT+Y14fhnzZlafwj4TGc+XHbO0kPSi55OedgejNm/avE2F6bTjxKdn0pvcyloyz5LH81SU7AtNylmlN0RFtHI/RGOCk9E6R3ReoOUB4Dp+fRxElXfuGw2PbvNrtl0agLEaTU7mun17mikKzLsDJbrbnP9I2km8f0N0xmWiNSGApaI1IIT1l6rUvGZREVki3LwznCvEZjZB8zse2bWMbODwyyjMywR6eeM66b708CvAv9r2AUUsERk0BjuYbn7UQCLnpFdQwFLRAbppnu3kuFMYgh4oRE/ER85HaREzDfTw9zRBAEAy+30mP5J25Zss0ZwOp3JMYjSCIJReTrBJ5mdsilaNpjAIpxkgky6RDTRRDwfSbzNYGKRqWZuNo71RROZQJw6sz1IT1hopNNmtln8+7Czsf56m6XMz7Whh5/3mNmRVV8fdvfDF78ws7+iO4HNWr/r7t/caM90hiUi/RwYvrzMSXdP3jB393eW0qceBSwRGTShl4RKaxCRNXqP5gzzGoGZvd/MjgH/Efg/ZvZQbhmdYYlIPwcfMcdqqM24fwP4xkaWUcASkUETmumugCUigyb0HpYCloj0c9/IKOFYjTcPyzxZJqYd1k6JS8hEM4VsC3JdXiGdSwWwHCQ3NYOZccIZdaaK/+UKJ/mJZqHJJBJHqTthLlVmyCZsj3ZDVCpnNs6lsiDPzYMdMRPkaE014m1GuU/RsTkXHJu5fKpzvv6URVEJnQ3RGZaI1IPj7WJJtptNAUtE+k1weRkFLBEZNIa0hiIUsESkjwOuMywRqQV3nWGJSH1M6k138zEOX5rZj4D/v+pbe4CTY+tAnvoTm7T+wOT1qer+vMHdXzvKCszsL+m+j2GcdPebR9neRow1YA1s3OxIVJpi3NSf2KT1ByavT5PWn61G1RpEpDYUsESkNqoOWIfzPzJW6k9s0voDk9enSevPllLpPSwRkY2o+gxLRGRolQQsM7vZzP7FzJ4xs09W0Yc1/XnOzJ4ysyfXzAAyzj7cY2YnzOzpVd/bbWYPm9m/9v6/q+L+fNrM/q23n540s/eMsT/7zeyvzexob7bg3+59v5J9FPSnsn10KRj7JaGZNYH/B7wLOAY8Btzq7t8fa0f6+/QccNDdK8ufMbP/DJwFvuzu1/a+9/vAKXe/sxfYd7n7f6+wP58Gzrr7H4yjD2v6sxfY6+5PmNkO4HHgfcBvUME+CvrzQSraR5eCKs6wbgCecfdn3X0Z+CpwSwX9mCju/ghwas23bwHu7f37Xrq/EFX2pzLuftzdn+j9+wxwFNhHRfso6I9soioC1j7gB6u+Pkb1H7QD3zKzx83sUMV9We1Kdz8O3V8Q4IqK+wNwu5l9t3fJOLZL1NXM7ABwPfAoE7CP1vQHJmAfbVVVBKz1SiJWPVR5o7v/DPBu4Ld6l0My6AvAm4DrgOPAZ8fdATPbDnwd+Li7nx739ofoT+X7aCurImAdA/av+vpq4IUK+vFj7v5C7/8n6E47dEOV/Vnlxd69kov3TE5U2Rl3f9Hd296dA+qLjHk/mdk03eDwFXe/v/ftyvbRev2peh9tdVUErMeAa8zsjWY2A3wIeKCCfgBgZgu9m6aY2QLwS8DT8VJj8wBwW+/ftwHfrLAvFwPCRe9njPvJzAy4Gzjq7p9b1VTJPkr1p8p9dCmoJHG0N9T7P4EmcI+7/97YO/GTvvwUP5nMcQr44yr6Y2b3ATfRfUr+ReBTwJ8BXwNeDzwPfMDdx3IjPNGfm+he6jjwHPCxi/ePxtCfdwB/AzwFP57Z4Q66943Gvo+C/txKRfvoUqBMdxGpDWW6i0htKGCJSG0oYIlIbShgiUhtKGCJSG0oYIlIbShgiUhtKGCJSG38O54/GRtTaBPwAAAAAElFTkSuQmCC\n",
+      "text/plain": [
+       "<Figure size 432x288 with 2 Axes>"
+      ]
+     },
+     "metadata": {
+      "needs_background": "light"
+     },
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "plt.imshow(diff_image2.value)\n",
+    "plt.colorbar()\n",
+    "plt.show()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 143,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "0.06228470265477223 ph / s\n"
+     ]
+    }
+   ],
+   "source": [
+    "diff_bkg, sky = estimate_background(diff_image)\n",
+    "print(sky)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 144,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "0.29583656042730927 ph / s\n"
+     ]
+    }
+   ],
+   "source": [
+    "diff_bkg, sky = estimate_background(diff_image2)\n",
+    "print(sky)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 160,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "0.2362643471925169 ph / s\n"
+     ]
+    }
+   ],
+   "source": [
+    "diff_bkg_mean, diff_bkg_median, sky = sigma_clipped_stats(diff_image, sigma=100)\n",
+    "print(sky)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 161,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "0.7860255862675863 ph / s\n"
+     ]
+    }
+   ],
+   "source": [
+    "diff_bkg_mean, diff_bkg_median, sky = sigma_clipped_stats(diff_image2, sigma=100)\n",
+    "print(sky)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 62,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAUkAAAD8CAYAAAD6+lbaAAAABHNCSVQICAgIfAhkiAAAAAlwSFlzAAALEgAACxIB0t1+/AAAADl0RVh0U29mdHdhcmUAbWF0cGxvdGxpYiB2ZXJzaW9uIDMuMC4zLCBodHRwOi8vbWF0cGxvdGxpYi5vcmcvnQurowAAIABJREFUeJzt3X2QJdV53/Hvb952l7flZfWCAWexWKUsKTG2tohSslVyCGilUrQoQdYSl4Qq2Cu7oGJV+Q+BXMIUMVXg6MVSQeQsZiNESVoIMtbEQUYIcBRVSWgXTAkB2rBG2IzYAqHFCIT2ZWae/NFnZvreO326p++dF3Z+H+oW9/bpPn1uz8yzp7ufPkcRgZmZzW9ouRtgZraSOUiamWU4SJqZZThImpllOEiamWU4SJqZZThImpllOEiamWU4SJqZZYz0s7GkLcBngGHgLyLi2tz6Y0NrY93w8e12lnswqOVTQ/VPG2XKV9iDSpKqC4dq/i3MlQ9Xl0WmrCivblOubDrzWxnD2V1my2M480PLlA3ntgOGh6Yry0aHpqq3U/V2wzW/YNL85S88/TIvP38o88tQ7x2/eWz85EB1u8se+N6huyJiSz/7W+laB0lJw8ANwHnABLBb0nhEPFq1zbrh4/nXJ/77djucqv6hxVT1L1t+u5pfhLbbLtajnkPVEWBobLSyTOvWZavVMdXlcdwxlWVT6/P1Hj5pTWXZoROrf/UOnVj9N54rAzh8YvWxP7K++mc2dMKRyrITjv95dp8nH/tyZdmr1r1Uvd1Y9XbHDh/K7nNU83+Xm//jvdntmvjJgSm+e9cvNlp3+NTHN/S9wxWun9Ptc4B9EfFERBwGdgFbB9MsM1suAUw3/G816Od0+zTgqdLnCeBf9dccM1tuQXAkmp1urwb9BMn5znt6znUkbQe2A6wdOq6P3ZnZUlktvcQm+gmSE8AZpc+nA093rxQRO4AdAOtHX7XCbneYWbcgmPIQirP6uSa5G9gk6UxJY8A2YHwwzTKz5TRNNHo1IWmLpL2S9km6fJ7yNZJuTeX3S9qYlp8i6T5JL0m6vmubv011PpRer87V1Y/WPcmImJR0GXAXRQrQzoh4pN8GVVJ1PK9KhwCIXGrMSpRpr4b6SPNZBpkfS7Ys97eX3a5228zxy2w3ldsOmM6UT05X/1yOTFdnKxzJZDLkRE1bG9UBTA0ox61hFswlwPMRcZakbcB1wPuBg8DHgTelV7ffjog9Xcuq6mqtr7+siLgzIl4fEa+LiGv6qcvMVo4B9iSbZMFsBW5O728HzpWkiPhZRHyLIlg2NW9dC9i+x8rrfpjZsgrgSESjVwPzZcGcVrVOREwCLwCnNKj7f6RT7Y+XAmHbuio5SJpZhyCYavgCNkjaU3pt76quSRZMo0yZLr8dEf8C+I30+kAfdWX19ViimR2FAqaah5XnImJzprxJFszMOhOSRoD1wIFsEyN+lP7/oqQvUZzWf6FNXXXckzSzDsUTN81eDTTJghkHLk7vLwTujczACpJGJG1I70eBdwPfb1NXE+5JmlkXMTXvWevCVWXBSLoa2BMR48BNwC2S9lH0+rbNtkR6EjgBGJN0AXA+8A/AXSlADgPfAG5Mm1TW1ZaDpJl1KG7cDC51LiLuBO7sWnZl6f1B4H0V226sqPbNFetX1tXW0gfJtnfjcxcGsvlvmfzK4XwuWq6PnvsWMZ0bYq3mJCWTD5ovy+VQ1hzzfrZdBG1zKAEqBscp5AZumqo+tpOT+d+Tg5PVf0YvT45Vlo1lhlGrUzUE2yB6gDGgeo4W7kmaWY9cgvxq4yBpZh3ck+zkIGlmHQIx5cSXWQ6SZtbDp9tzHCTNrEMgDtdNJrSKOEiaWYcimdyn2zOWOEgKatJuKuUm3srUmU3Vqdll221zQ7cVua/tKDM7YTadqW7YrWUYTk65NKnpzHBxNVkzQ1PV2w4dqS6bOpwZ0uxw/s/k4Gj1JGwvZWZSzDmcGUYNYKSi3qlMyttC+MbNHPckzaxDhAYWbI8GDpJm1mPaPclZDpJm1qG4cePQMMNHwsw6+MZNJwdJM+tRN6/PauIgaWYd/MRNp6UNkgK1ndUvk6YSU+3SLOr+rcyn+eRGHlqkOYtzaT65NKhM6lCxbcvRhepkR0OqLsoNjjM0md+ljuTKMqlFR6qPwdThfDrOy8PVI/3k5HprP5+sTiuC6hSg3OyMCzHtu9uz3JM0sw7FABcOkjMcJM2sQyCO+LHEWQ6SZtYhYnBP7hwNHCTNrIucTF7iIGlmHQL3JMt8JMysxxRDjV5NSNoiaa+kfZIun6d8jaRbU/n9kjam5adIuk/SS5KuL61/jKT/LekHkh6RdG2p7EOSfizpofT6nX6PxRKnAAlGKnZZlzaTKc+l40RmRJm69BYNZ9qUG5Uol/pSJzfxVm4isKrjCvUjL+XSsvqYJCw3GJIyWVu5kX5UkwI0nEkBmj5cXRYHMyME1Ry/zC75Web378hUdb2jw/nhjqpGmhpEClCggQ26K2kYuAE4D5gAdksaj4hHS6tdAjwfEWdJ2gZcB7wfOAh8HHhTepV9IiLuS3N53yPpnRHxtVR2a0RcNpAvQJ9BMs2J+yLFPHSTEbF5EI0ys+VTTCk7sP7TOcC+iHgCQNIuYCtQDpJbgavS+9uB6yUpIn4GfEvSWR3ti3gZuC+9PyzpQeD0QTW42yBOt38zIs52gDQ7Woiphq8GTgOeKn2eSMvmXSciJoEXgFMatVQ6Efh3wD2lxf9B0vck3S7pjCb15PiapJl1CIonbpq8gA2S9pRe27uqmy+Sdl8raLJOD0kjwJeBz870VIH/BWyMiH8JfAO4ua6eOv32qQP4uooLJP89InZ0r5AO2naAtcPH97k7M1sKCxiZ/Lmas8gJoNybOx14umKdiRT41gMHGux7B/B4RPzZzIKI+Emp/EaK65t96bcn+daI+DXgncClkt7WvUJE7IiIzRGxeWx4XZ+7M7PFFqGF9CTr7AY2SToz3WTZBox3rTMOXJzeXwjcG5G/kyvpTyiC6Ue6lp9a+vge4LEmjczpqycZEU+n/z8r6Q6Ki7Tf7LdRZrZ8ihs3g3ksMSImJV0G3EUxwdPOiHhE0tXAnogYB24CbpG0j6IHuW1m+3Rz+ARgTNIFwPnAT4E/An4APJiyW66PiL8A/rOk9wCTqa4P9fsdWgdJSccCQxHxYnp/PnB1vw0ys+U22DluIuJO4M6uZVeW3h8E3lex7caKaue9HhARVwBXtGpohX56kq8B7khRfAT4UkT8TX4T5Yflysn1vjO5YZrOJOTVDNsW2W0z/9JGu6HbauWGQ8t9l5F8ryAyP5MYXpzH03KzJQ5NVZfl8iABpjPDoQ0dqi7LpUJGLj+VfFrskczsjZNHqnc6NJL/HaqqdWpqEHmSDCxP8mjQOkimu0m/MsC2mNkK4aHS5vjZbTPrMMgnbo4GDpJm1sMTgc1xkDSzDhFwZEDTQBwNHCTNrENxuu0gOcNB0sx6LOCJm6Peks+WGDXpKJWb5vIshnKz8mX+RawZnk25WRizKUl9pAC1HbYsl1pVN1Ra7meSaU/UzaSYGyotNxxaH0OlDWWGQ8sehpph33KmMqemuZSkGM3M0Jj7nYbqHKDc0IANOQWok3uSZtbFp9tlDpJm1sNz3MxxkDSzDsXdbU8pO8NB0sw6OJm8k4OkmfXw6fYcB0kz6+C7252WfrbE0Xa7jFwKUC4dp20ZoKGWKUCLJTcrZB8pQJEpz44C1Mff0WKNAhS5GRGzM1FmKq1Jq8mlLGVTgHIjD+Vm6gQqY1hm1KGF8N3tOe5JmlmHCDHpIDnLQdLMevh0e46DpJl18DXJTg6SZtbDQXKOg6SZdXCeZCdfnTWzHtOo0asJSVsk7ZW0T9Ll85SvkXRrKr9f0sa0/BRJ90l6SdL1Xdu8WdLDaZvPKk22JelkSXdLejz9/6R+j8WSpwDl0k2ym9aNilKljxSgbBpGH/Vm1Y2sUyWXAlQz4Rm5NJ+2oxLVaTlC0FA/owAp93Op/i6qGdRpOpN2M535C8umANWNSlTxXera2kQETA5o0F1Jw8ANwHnABLBb0nhEPFpa7RLg+Yg4S9I24Drg/cBB4OPAm9Kr7HPAduA7FDMxbgG+BlwO3BMR16aAfDnw0X6+g3uSZtZjOtTo1cA5wL6IeCIiDgO7gK1d62wFbk7vbwfOlaSI+FlEfIsiWM6SdCpwQkR8OyIC+AJwwTx13Vxa3pqDpJl1mLkmOaAgeRrwVOnzRFo27zoRMQm8AJxSU+dERZ2viYj9qa79wKubNDLHN27MrEc0v3GzQdKe0ucdEbGj9Hm+irqvFTRZp5/1++IgaWY9FjDAxXMRsTlTPgGcUfp8OvB0xToTkkaA9cCBmjpPr6jzGUmnRsT+dFr+bIPvkOXTbTPrEDHQa5K7gU2SzpQ0BmwDxrvWGQcuTu8vBO5N1xor2hf7gRclvSXd1f4g8NV56rq4tLw19yTNrIuy8/YsRERMSroMuAsYBnZGxCOSrgb2RMQ4cBNwi6R9FD3IbbMtkZ4ETgDGJF0AnJ/ujP8+8HlgHcVd7a+lTa4FbpN0CfCPwPv6/Q4OkmbWYwHXJBvUFXdSpOmUl11Zen+QimAWERsrlu+hNy2IiPgJcG4fze1RGyQl7QTeDTwbEW9Ky04GbgU2Ak8CvxURz9fVFYIYnT85THU5i9nCRcpZzOSc1bV3MWRnJ8z9w1+TJxkjmRkRMzmU/fwd5VIWc8Oo5XIooWYotczxy/08p2qGH8vN4DiUHQ4tU1bXkav4LgPJk8SPJZY16VN/niJRs2wmYXMTcE/6bGZHgyj6Fk1eq0FtkIyIb9J7p2ngCZtmtnIM8rHEV7q21yQ7EjYlVSZsStpO8fgQa8fWt9ydmS2VGOCNm6PBoh+JiNgREZsjYvPoyDGLvTszGwCfbs9pGySfSYmaDCph08xWjgg1eq0GbYPkwBM2zWxlKHqJDpIzmqQAfRl4O8UzmhPAH9M6YVNQkW5S23Nv27dfpBSg7IOli3QesmgpQLk0n+wsjHXDeeWLKzfLDZVWkwKUS50ZOpJLFcs0NjdTZ02bprPD0LVrDlB5bAeRAgROASqrDZIRcVFF0UATNs1s5Vgt1xub8BM3ZtYhENO+uz3LQdLMergjOcdB0sw6xWCf3X6lc5A0s17uSs5ykDSzHu5Jzlni2RJhOjPiTOtq296Kq0ntoN3Ejn39K9z6dzMzu142dahu25ZlxX7zu20jN0IQ1KQIZY9DZuShmi8ynRstKjfLZz8pQJWNablded/A9LSD5Az3JM2sU7A4/8K9QjlImlkP50nOcZA0s14OkrMcJM2sy+p5LrsJB0kz6+We5Cw/e2RmnQJiWo1eTUjaImmvpH2SeqZ6kbRG0q2p/H5JG0tlV6TleyW9Iy3755IeKr1+KukjqewqST8qlb2r38Ox5ClAuRFnWmt7atA2xQeyV7b7+ke4Ll2nap+5zWpTgDL19pMCtEiTiOV3Wl2UGyEnf4hq0o4yXyY3KlGurOWvwQAnVBhMTZKGgRuA84AJYLek8TQt7IxLgOcj4ixJ24DrgPdLegPF9LJvBH4B+Iak10fEXuDsUv0/Au4o1ffpiPjEQL4A7kma2Xyi4aveOcC+iHgiIg4DuyjmyCorz5l1O3CuJKXluyLiUET8ENiX6is7F/j7iPiHBX2/BXCQNLNegwuSpwFPlT5PpGXzrhMRk8ALwCkNt90GfLlr2WWSvidpp6STGrUyw0HSzDrNJJM3eRWDce8pvbZ31TbfeXt3eK1aJ7utpDHgPcD/LJV/Dngdxen4fuCTua/ahO9um1mPBSSTPxcRmzPlE8AZpc+nA09XrDMhaQRYTzGNdd227wQejIhn5to9917SjcBfN/4mFdyTNLNe02r2qrcb2CTpzNTz20YxR1ZZec6sC4F7IyLS8m3p7veZwCbgu6XtLqLrVHtmgsLkvcD3G37jSu5JmlkPDShPMiImJV0G3EWRT7IzIh6RdDWwJyLGgZuAWyTto+hBbkvbPiLpNuBRYBK4NCKmACQdQ3HH/MNdu/xTSWdTnJY/OU/5gjlImlmn5jdlmlUXcSdwZ9eyK0vvD1IxmWBEXANcM8/ylylu7nQv/0C/7e22xHmSIloOlZYbDm15Hg5YWY9tZYdDq2lqbttsnl9Nzms2jzJbb6asLoFwZf1Y8j2ytmVk8kwH8segzA5WH/ckzayXH0uc5SBpZr0GNH/30cBB0sw6edDdDg6SZtZjUHe3jwYOkmbWy0FylpPJzcwyanuSknYC7waejYg3pWVXAb8L/Dit9rGUC5UV1A+vVb1tu+1az6S4TGpTXKpkNqu7vJRN5WmZHlSUZ7bN/Oblh2fL73M6Nzxb27SjuiHh2s562MfPbNDbdfPp9pwmPcnPA1vmWf7piDg7vWoDpJm9QgSDfCzxFa82SEbENykeFTKz1WJwQ6W94vVzTXKgY7aZ2cqhaPZaDdoGycZjtknaPjPW3JEjP2u5OzNbUu5JzmoVJCPimYiYiohp4EZ6h1Qvr7sjIjZHxObR0WPbttPMlpKD5KxWQXIxxmwzs5Wh6an2ajndbpIC9GXg7RTDtE8Afwy8ve2YbXUpHAO3wh6v6qs5udSYPmZLzP5MMptOj7QfBahtys10zQyXuXoXIz2odtuWx3YxUsEWZJXcuW6iNkhGxEXzLL5pEdpiZivEauklNuHHEs2sl4PkLAdJM+u0iq43NuEgaWa9HCRnOUiaWQ950N1ZHgXIzBaVpC2S9kraJ+nyecrXSLo1ld8vaWOp7Iq0fK+kd5SWPynpYUkPSdpTWn6ypLslPZ7+3/fTgA6SZtZrQMnkkoaBG4B3Am8ALpL0hq7VLgGej4izgE8D16Vt30AxvewbKQbZ+W+pvhm/mQbY2VxadjlwT0RsAu5Jn/uyxLMlks31WwyvtEsrbfMds9vVDWmWq7flkGaQz2nM5Vi2zXUs6q0uy+ZmZsvaf8/srJBth1jLGEge8mBv3JwD7IuIJwAk7QK2UsylPWMrcFV6fztwvSSl5bsi4hDwwzQv9znAtzP720qR1w1wM/C3wEf7+QLuSZpZr8E9lnga8FTp80RaNu86ETEJvEAxp3Zu2wC+LukBSdtL67wmIvanuvYDr27UygzfuDGzXs17khvK1wSBHRGxo/R5vj5xd+1V6+S2fWtEPC3p1cDdkn6QhnUcOAdJM+sgFnR3+7mua4LdJoAzSp9PB56uWGdC0giwnmIM28ptI2Lm/89KuoPiNPybwDOSTo2I/WmMiWcbf5MKPt02s06DHeBiN7BJ0pmSxihuxIx3rTMOXJzeXwjcGxGRlm9Ld7/PBDYB35V0rKTjASQdC5zP3CA75bouBr7a5hCUuSdpZr0GdOMmIiYlXQbcBQwDOyPiEUlXA3siYpxiLIhb0o2ZAxSBlLTebRQ3eSaBSyNiStJrgDuKezuMAF+KiL9Ju7wWuE3SJcA/Au/r9zs4SJpZrwGmhaQ5sO7sWnZl6f1BKoJZRFwDXNO17AngVyrW/wlwbp9N7rDkQbLtbIm8wmY9bG0R0nxqZ/trO7xYH+k4uRSgqdHq7XIpSXX1ZtODsm3N77P9LIyZSuv+TCrK64Z1a8rPbs9xT9LMejlIznKQNLNO4We3yxwkzayXe5KzHCTNrIevSc5xkDSzXg6SsxwkzazTKpoutomlTwGqSF2o7d63nT0uZ7HSivpoa+s0n1zqUE1aSNs0n1yqDtSk42S2nRprtx3A9FiuPZmybNpR/vek9chDuRSgoXa/m4MYBUj4dLvMPUkz6+EgOcdB0sx6OUjOcpA0s14OkrMcJM2sk6eU7eAgaWa9HCRnOUiaWQ8/ljinNkhKOgP4AvBaYJpiePbPSDoZuBXYCDwJ/FZEPN+2IW0nPoI+Tg0WI62oRu33bDtIUi7VpOZ75tJG2k7mBTVpPmsyaT6ZNJ6pNdldMpVLARqr/kXJtTW3HUCMVpdn04dyaT51KUBVh294MF1An27PaZJVNQn8YUT8MvAW4NI01ePAp240sxWg6SRgqySQ1gbJiNgfEQ+m9y8Cj1HMWLaVYspG0v8vWKxGmtkSc5CctaBrkpI2Ar8K3E/X1I1p1jIze4XzEzedGgdJSccBXwE+EhE/VcPreWlO3O0Aa9ae2KaNZrbENO0oOaPRk56SRikC5Bcj4i/T4mfSlI3kpm6MiB0RsTkiNo+OHTuINpvZYvI1yQ61QVJFl/Em4LGI+FSpaOBTN5rZyjDAKWWRtEXSXkn7JPXc4E1Txt6ayu9Pl/Vmyq5Iy/dKekdadoak+yQ9JukRSX9QWv8qST+S9FB6vavfY9HkdPutwAeAhyU9lJZ9jEWYutHMVogB9RIlDQM3AOcBE8BuSeMR8WhptUuA5yPiLEnbgOuA96csmm3AG4FfAL4h6fXMZdw8mObffkDS3aU6Px0RnxjMN2gQJCPiW1RnZS1s6kZlaurjh5LLPTyaLkBn8x0zRXXDZ+VmU2w7+yDUDHmWyWecXFtdNl2XJ7m2+gc+tSaTJ7kmkz09ls+sVqZ8ZKS6bHhkqrJsqCZPUhW/2EOZ/S3EAP9uzgH2pWlgkbSLIjOmHCS3Alel97cD16cz2K3Arog4BPwwzct9TkR8G5i5afyipJmMm3KdAzOA0efM7KgzuGuSpwFPlT5PpGXzrhMRk8ALwClNtu3KuJlxmaTvSdop6aRGrcxwkDSzTmm2xCYvYIOkPaXX9q7a5jud6A6vVetkt+3OuEmLPwe8Djiborf5ybqvW8fPbptZhwXmST4XEZsz5RPAGaXPpwNPV6wzIWkEWA8cyG1bkXFDRDwz+z2kG4G/bvxNKrgnaWa9Ipq96u0GNkk6U9IYxY2Y8a51ypkyFwL3RkSk5dvS3e8zgU3AdzMZNzPpiDPeC3x/gd+8h3uSZtZjUDduImJS0mXAXcAwsDMiHpF0NbAnIsYpAt4t6cbMAYpASlrvNoobMpPApRExJenXmSfjJiLuBP5U0tkUp+VPAh/u9zs4SJpZpwEniqfgdWfXsitL7w9SkUIYEdcA13Qtq8y4iYgP9NvebisnSNY95bgcqTxtZ1PMpOrU/Qvdz5Bx1Tut2WduFsZcWc1vT36otMx2mbLJTIoPwNQx1Skwsba6TGur03FG10xm97lmzZHKsrWj1duODWf2mSkDGKr4RZoYHlAKkMeTnLVygqSZrRgOknMcJM2sU7B4c9K/AjlImlmPo+lJtX45SJpZLwfJWQ6SZtbBg+52cpA0s04RHnS3ZHUHycW6OJ2rd5FmaMyNEFSXVpRN88nNljjcfrbEfHpQZiSfdTUzF67LjLpzTHU6ztp1hyvLjlt7KLvP49dUlx8/erCy7JiR6tShNUP5tKOqFKCHa7ZrzDFy1uoOkmY2L59uz3GQNLNOAfh0e5aDpJn1coyc5SBpZj18uj3HQdLMevju9hwHSTPrtIqmi23iqAiSi3Vq0LbeRRnJpx81aUe5icD6GQUoVz49mpmUa6y6LHITdgFD66pTYNYdU52qs35ddarOyetezu7zlDU/q952tLrshJHqfa4dqk4PAhjV/KMEfX04v10TRTK5o+SMoyJImtmAeRSgWQ6SZtbDPck5DpJm1snXJDs4SJpZFz+7XeYgaWa9fLo9y0HSzDqFp28o87zbZtZrcPNuI2mLpL2S9km6fJ7yNZJuTeX3S9pYKrsiLd8r6R11dab5ve+X9Hiqc6yv40CDnqSkM4AvAK+lSAzYERGfkXQV8LvAj9OqM/PeriyZH+Ry5FdG3RXxRUiyrK0yU952GDWA6dwwa5lf3enMUGm5WQ0B1qytzhM8IZMLuWFddT7ja9b9NLvP166pLt8w8lJl2cmZsmOH8sOzDVXk6KxR/3mSwMBu3EgaBm4AzgMmgN2SxiPi0dJqlwDPR8RZkrYB1wHvl/QGijm43wj8AvANSa9P21TVeR3w6YjYJenPU92f6+c7NOlJTgJ/GBG/DLwFuDQ1ntSYs9Nr5QVIM2tF09ONXg2cA+yLiCci4jCwC9jatc5W4Ob0/nbgXElKy3dFxKGI+CGwL9U3b51pm3+T6iDVeUHrg5DUBsmI2B8RD6b3LwKPAaf1u2MzW6GC4pyxyQs2SNpTem3vqu004KnS5wl648fsOhExCbwAnJLZtmr5KcA/pTqq9rVgC7pxk64V/CpwP/BW4DJJHwT2UPQ2n59nm+3AdoA1607ss7lmtthELCSZ/LmI2Jytrld35VXrVC2fr3OXW78vjW/cSDoO+ArwkYj4KcV5/uuAs4H9wCfn2y4idkTE5ojYPDp2bL/tNbOlMLgbNxPAGaXPpwNPV60jaQRYDxzIbFu1/DngxFRH1b4WrFGQlDRKESC/GBF/CRARz0TEVERMAzdSXCcws6PB4ILkbmBTuus8RnEjZrxrnXHg4vT+QuDeiIi0fFu6+30msAn4blWdaZv7Uh2kOr/a+hgkTe5uC7gJeCwiPlVafmpE7E8f3wt8v9/GmNkKMHNNchBVRUxKugy4CxgGdkbEI5KuBvZExDhFfLlF0j6KHuS2tO0jkm4DHqW4gXxpREwBzFdn2uVHgV2S/gT4u1R3X5pck3wr8AHgYUkPpWUfAy6SdDbFIX0S+HBfLVmJCf6L8WhWzQyDyyGXIpRNAao5D8nPtJjZbqT6uA+P5VOA1o5Vp8AcP1adVpMb7iyX4gNw2ljPpfi5bUf+qXqfw5kUoJpUnqrZEsc0mNkSG965biRlvtzZtezK0vuDwPsqtr0GuKZJnWn5Ewz4rLY2SEbEt5j/gqhTfsyOSs0TxVcDP5ZoZp0CB8kSB0kz6+Vnt2c5SJpZDw+6O8dB0sx6OUjOcpA0s04RMOXz7RlHfZBcaZOs17YnO4JQ2532Ud4yPQjyKUAxnPk2I9V/oCMj+RSgdZkUoBPGqkcBOnG0ekbE3Eg+AK8eqU4Reu3IC5Vlp2RG+jmm5mc2WjED5tigMszck5x11AdJM2vBQXKWg6SZdQoW50GKVygHSTPrEhC+JjnDQdLMOgW+cVPiIGlmvXxNcpaDpJn1cpCctbRBMmidx5JNnWn7A+3j4nR2sq+VN9BPa1GRagLUphbFUOYg5dKHMmXDw/nXJMo9AAAFu0lEQVTTwLHh6hShtcPV6UHHjVSn4xw//PPsPk8cqk4fOnHocGXZ+qHqA3j8UH6Sv6GKgzRcm+/VhAe4KHNP0sw6BTDAodJe6RwkzayXe5KzHCTNrIsfSyxzkDSzTgHhPMlZDpJm1stP3MxykDSzXr4mOavxvNtmtkpEFHe3m7z6IOlkSXdLejz9/6SK9S5O6zwu6eLS8jdLeljSPkmfTTO7Ium/SvqBpO9JukPSiWn5Rkk/l/RQev15k3a6J5mx0oZZW2n6yQfNbps58Lm0TaieRRBgOFM2qur8ylxZUV49Q+FoJjF4VNVjyY2QGWcOGNb8/RsNJE+SpepJXg7cExHXSro8ff5oeQVJJwN/DGymSE56QNJ4RDwPfA7YDnyHYmLCLcDXgLuBK9J0ttcBV5Tq/fuIOHshjXRP0sy6BDE11ejVp63Azen9zcAF86zzDuDuiDiQAuPdwBZJpwInRMS3IyKAL8xsHxFfj4iZf7m+A5zeTyMdJM2s08xQaU1esEHSntJr+wL29JqI2A+Q/v/qedY5DXiq9HkiLTstve9e3u0/UfQuZ5wp6e8k/R9Jv9GkkT7dNrNezVOAnouIzVWFkr4BvHaeoj9qWP981w8is7y87z8CJoEvpkX7gV+MiJ9IejPwV5LeGBHVQ8vjIGlmXQKIAaUARcS/rSqT9IykUyNifzp9fnae1SaAt5c+nw78bVp+etfyp0t1Xwy8Gzg3nY4TEYeAQ+n9A5L+Hng9sCf3HXy6bWadIg262+TVn3Fg5m71xcBX51nnLuB8SSelu9/nA3el0/MXJb0l3dX+4Mz2krZQ3Kh5T0TMjj4i6VVScbdM0i8Bm4An6hrpnqSZ9RjATZkmrgVuk3QJ8I/A+wAkbQZ+LyJ+JyIOSPovwO60zdURcSC9/33g88A6iuuOM9cerwfWAHenrKDvRMTvAW8DrpY0CUylfczUVUmxhEmjkn4M/ENp0QbguSVrQD23J2+ltQdWXpuWuz3/LCJe1U8Fkv6G4ns08VxEbOlnfyvdkgbJnp1Le3IXfZea25O30toDK69NK6091j9fkzQzy3CQNDPLWO4guWOZ99/N7clbae2BldemldYe69OyXpM0M1vplrsnaWa2oi1LkJS0RdLeNMTR5cvRhq72PJmGXHpIUjb7fhHbsFPSs5K+X1rWaCipJWzPVZJ+VBpq6l1L2J4zJN0n6TFJj0j6g7R8WY5Rpj3LdoxscSz56XbKeP9/wHkUjxbtBi6KiEeXtCGdbXoS2BwRy5bfJultwEvAFyLiTWnZnwIHSkNJnRQRH83Vs8jtuQp4KSI+sRRt6GrPqcCpEfGgpOOBByhGffkQy3CMMu35LZbpGNniWI6e5DnAvoh4IiIOA7sohkxa1SLim0B39n+ToaSWsj3LJiL2R8SD6f2LwGMUo74syzHKtMeOMssRJKuGPlpOAXxd0gMLHOppsTUZSmqpXZZGfN65lKf/ZZI2Ar8K3M8KOEZd7YEVcIxscJYjSNYOcbQM3hoRvwa8E7g0nWpar88BrwPOphh26pNL3QBJxwFfAT5SN8TVMrVn2Y+RDdZyBMkJ4IzS544hjpZDRDyd/v8scAfFJYGV4Jl07WvmGth8Q0ktmYh4JiKmophv9EaW+DhJGqUISF+MiL9Mi5ftGM3XnuU+RjZ4yxEkdwObJJ0paQzYRjFk0rKQdGy68I6kYymGYvp+fqsl02QoqSUzE4yS97KExykNh3UT8FhEfKpUtCzHqKo9y3mMbHEsSzJ5Sov4M2AY2BkR1yx5I+ba8ksUvUcoho770nK0R9KXKQYX3QA8QzH50V8BtwG/SBpKqsnQTovYnrdTnEYG8CTw4ZnrgUvQnl8H/i/wMDAzkOHHKK4DLvkxyrTnIpbpGNni8BM3ZmYZfuLGzCzDQdLMLMNB0swsw0HSzCzDQdLMLMNB0swsw0HSzCzDQdLMLOP/A1y3Fxd7rKQhAAAAAElFTkSuQmCC\n",
+      "text/plain": [
+       "<Figure size 432x288 with 2 Axes>"
+      ]
+     },
+     "metadata": {
+      "needs_background": "light"
+     },
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "plt.imshow(diff_bkg.value)\n",
+    "plt.colorbar()\n",
+    "plt.show()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python [conda env:duet]",
+   "language": "python",
+   "name": "conda-env-duet-py"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.6.8"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}


### PR DESCRIPTION
For the small postage stamp images that we're using for the simulations at the moment it's better to use a 1D sigmaclipped estimate of the background, as the 2D backgrounds introduce artifacts. I've added a method keyword to estimate_background that defaults to 2D (current behavior), but should be set to 1D when using estimate_background for background subtraction in small simulated images.