### PR TITLE
Config updates for jitter_rms

### DIFF
--- a/astroduet/config.py
+++ b/astroduet/config.py
@@ -184,7 +184,7 @@ class Telescope():
 
         # Transmission through the Schmidt plates
         self.trans_eff = (0.975)**8 # from Jim.
-        self.jitter_rms = 1 * u.micron * self.plate_scale
+        self.jitter_rms = 11.8 * u.micron * self.plate_scale
 
         # Below are in 
         self.psf_params = {

--- a/astroduet/config.py
+++ b/astroduet/config.py
@@ -184,6 +184,7 @@ class Telescope():
 
         # Transmission through the Schmidt plates
         self.trans_eff = (0.975)**8 # from Jim.
+        self.jitter_rms = 1 * u.micron * self.plate_scale
 
         # Below are in 
         self.psf_params = {
@@ -218,6 +219,7 @@ class Telescope():
 
         # Transmission through the Schmidt plates
         self.trans_eff = (0.975)**8 # from Jim.
+        self.jitter_rms = 11.8 * u.micron * self.plate_scale
 
         # Below are in 
         self.psf_params = {
@@ -287,6 +289,7 @@ class Telescope():
 
         # Transmission through the Schmidt plates
         self.trans_eff = (0.975)**8 # from Jim.
+        self.jitter_rms = 11.8 * u.micron * self.plate_scale
 
         self.psf_params = {
         'sig':[2.8*u.micron*self.plate_scale],
@@ -320,6 +323,7 @@ class Telescope():
 
         # Transmission through the Schmidt plates
         self.trans_eff = (0.975)**8 # from Jim.
+        self.jitter_rms = 11.8 * u.micron * self.plate_scale
 
         self.psf_params = {
         'sig':[4.8*u.micron*self.plate_scale],
@@ -350,6 +354,7 @@ class Telescope():
         pixel = 10*u.micron
         self.plate_scale = 5.03*u.arcsec / pixel  # arcsec per micron
         self.pixel = self.plate_scale * pixel
+        self.jitter_rms = 11.8 * u.micron * self.plate_scale
 
         # Transmission through the Schmidt plates
         self.trans_eff = (0.975)**8 # from Jim.
@@ -384,6 +389,7 @@ class Telescope():
         pixel = 10*u.micron
         self.plate_scale = 6.4*u.arcsec / pixel  # arcsec per micron
         self.pixel = self.plate_scale * pixel
+        self.jitter_rms = 11.8 * u.micron * self.plate_scale
 
         # Transmission through the Schmidt plates
         self.trans_eff = (0.975)**8 # from Jim.

--- a/astroduet/models.py
+++ b/astroduet/models.py
@@ -54,14 +54,24 @@ class Simulations():
 
 
 
-    def parse_emgw(self):
+    def parse_emgw(self, diag=False):
         '''
         Loop over each EMGW GRB shock model and save the outputs
+    
+        Optional parameters
+        -------------------
+        
+        diag: boolean
+            Just run one test instead of looping over all for unit tests
+
 
         '''
 
         self.emgw_processed = np.array([])
-        for shockf in self.emgw_simulations:
+        for ind, shockf in enumerate(self.emgw_simulations):
+            if diag is True:
+                if ind > 0:
+                    break
             sname = os.path.splitext(shockf)[0]
             print('Parsing and storing: {}'.format(sname))
             outfile = datadir+'/'+sname+'_lightcurve_DUET.fits'

--- a/astroduet/tests/test_all_sims.py
+++ b/astroduet/tests/test_all_sims.py
@@ -5,4 +5,4 @@ import astropy.units as u
 def test_sims():
     # Just test that it runs ok
     sims = Simulations()
-    sims.parse_emgw()
+    sims.parse_emgw(diag=True)

--- a/astroduet/tests/test_lightcurve.py
+++ b/astroduet/tests/test_lightcurve.py
@@ -68,5 +68,5 @@ def test_numerically_realistic_lightcurve():
     fl1_out = lc_out['fluence_D1_fit'].value
     fl2_out = lc_out['fluence_D2_fit'].value
 
-    assert np.allclose(np.mean(fl1_out), ref_fluence.value, rtol=0.1)
-    assert np.allclose(np.mean(fl2_out), ref_fluence.value, rtol=0.1)
+#    assert np.allclose(np.mean(fl1_out), ref_fluence.value, rtol=0.1)
+#    assert np.allclose(np.mean(fl2_out), ref_fluence.value, rtol=0.1)

--- a/astroduet/tests/test_lightcurve.py
+++ b/astroduet/tests/test_lightcurve.py
@@ -68,5 +68,5 @@ def test_numerically_realistic_lightcurve():
     fl1_out = lc_out['fluence_D1_fit'].value
     fl2_out = lc_out['fluence_D2_fit'].value
 
-#    assert np.allclose(np.mean(fl1_out), ref_fluence.value, rtol=0.1)
-#    assert np.allclose(np.mean(fl2_out), ref_fluence.value, rtol=0.1)
+    assert np.allclose(np.mean(fl1_out), ref_fluence.value, rtol=0.1)
+    assert np.allclose(np.mean(fl2_out), ref_fluence.value, rtol=0.1)


### PR DESCRIPTION
Fixes #89 and #90

Duplicated jitter_rms value for all configurations (currently set to 11.8 microns RMS). This will need to be tuned for each model. Note that right now is based on a large (5" RMS) pointing jitter, which I think is larger than we expect it to be. But that's TBD for next week.

Added diag option to SImulations().parse_emgw() to only load one of the models during the unit tests to speed up TravisCI