### PR TITLE
Update to find and run_daophot

### DIFF
--- a/astroduet/image_utils.py
+++ b/astroduet/image_utils.py
@@ -520,7 +520,7 @@ def run_daophot(image,threshold,star_tbl,niters=1,snr_lim=5, duet=None,diag=Fals
     residual_image = photometry.get_residual_image()
     
     # Filter results to only keep those with S/N greater than snr_lim (default is 5)
-    result_sig = result[result['flux_fit']/result['flux_unc'] >= snr_lim]
+    result_sig = result[np.abs(result['flux_fit']/result['flux_unc']) >= snr_lim]
     
     if diag:
         print("PSF-fitting complete")
@@ -528,7 +528,7 @@ def run_daophot(image,threshold,star_tbl,niters=1,snr_lim=5, duet=None,diag=Fals
     # Turn warnings back on again
     warnings.simplefilter('default')
     ## FROM HERE ON YES UNITS ###########
-    result['flux_fit'] = result['flux_fit'] * image.unit
-    result['flux_unc'] = result['flux_unc'] * image.unit
+    result_sig['flux_fit'] = result_sig['flux_fit'] * image.unit
+    result_sig['flux_unc'] = result_sig['flux_unc'] * image.unit
 
     return result_sig, residual_image * image.unit

--- a/astroduet/image_utils.py
+++ b/astroduet/image_utils.py
@@ -410,7 +410,7 @@ def find(image,fwhm,method='daophot',background='1D',frame='diff',diag=False):
         find_image = image - bkg_image
 
     # Look for five-sigma detections
-    threshold = 5 * sky
+    threshold = 2 * sky
 
     # Make sure the image and threshold units are the same
     threshold = threshold.to(image.unit)
@@ -475,7 +475,7 @@ def ap_phot(image,star_tbl,read_noise,exposure,r=1.5,r_in=1.5,r_out=3.):
 
     return result, apertures, annulus_apertures
 
-def run_daophot(image,threshold,star_tbl,niters=1,duet=None,diag=False):
+def run_daophot(image,threshold,star_tbl,niters=1,snr_lim=5, duet=None,diag=False):
     '''
         Given an image and a PSF, go run DAOPhot PSF-fitting algorithm
     '''
@@ -512,13 +512,16 @@ def run_daophot(image,threshold,star_tbl,niters=1,duet=None,diag=False):
     # Initialise a Photometry object
     # This object loops find, fit and subtract
     threshold = threshold.to(image.unit)
-    photometry = DAOPhotPSFPhotometry(3.*fwhm,threshold.value,fwhm,psf_model,(5,5),
-        niters=niters,sigma_radius=5, aperture_radius=2.)
+    photometry = DAOPhotPSFPhotometry(fwhm,threshold.value,fwhm,psf_model,(5,5),
+        niters=niters,sigma_radius=5, aperture_radius=fwhm)
 
     # Problem with _recursive_lookup while fitting (needs latest version of astropy fix to modeling/utils.py)
     result = photometry(image=image.value, init_guesses=star_tbl)
     residual_image = photometry.get_residual_image()
-
+    
+    # Filter results to only keep those with S/N greater than snr_lim (default is 5)
+    result_sig = result[result['flux_fit']/result['flux_unc'] >= snr_lim]
+    
     if diag:
         print("PSF-fitting complete")
 
@@ -528,4 +531,4 @@ def run_daophot(image,threshold,star_tbl,niters=1,duet=None,diag=False):
     result['flux_fit'] = result['flux_fit'] * image.unit
     result['flux_unc'] = result['flux_unc'] * image.unit
 
-    return result, residual_image * image.unit
+    return result_sig, residual_image * image.unit

--- a/astroduet/image_utils.py
+++ b/astroduet/image_utils.py
@@ -409,7 +409,7 @@ def find(image,fwhm,method='daophot',background='1D',frame='diff',diag=False):
         bkg_image, sky = estimate_background(image, method=background, sigma=2, diag=diag)
         find_image = image - bkg_image
 
-    # Look for five-sigma detections
+    # Look for sources at twice the background RMS level
     threshold = 2 * sky
 
     # Make sure the image and threshold units are the same

--- a/astroduet/imsim.py
+++ b/astroduet/imsim.py
@@ -62,7 +62,7 @@ def imsim(**kwargs):
     nsrc = kwargs.pop('nsrc', 100)
     run = kwargs.pop('run')
     stack = kwargs.pop('stack', 1)
-    ref_arr = kwargs.pop('nref',[1,3,5,8])
+    ref_arr = kwargs.pop('nref',[1,3,7,11])
 
     # set some telescope, instrument parameters
     duet = Telescope(config=tel)

--- a/astroduet/lightcurve.py
+++ b/astroduet/lightcurve.py
@@ -777,7 +777,7 @@ def lightcurve_through_image(lightcurve, exposure,
 
         with suppress_stdout():
             result1, _ = run_daophot(diff_image1, threshold,
-                                     star_tbl, niters=1, duet=duet)
+                                     star_tbl, niters=1, snr_lim=0., duet=duet)
 
         fl1_fit = result1['flux_fit'][0] * image_rate1.unit
         fl1_fite = result1['flux_unc'][0] * image_rate1.unit
@@ -800,7 +800,7 @@ def lightcurve_through_image(lightcurve, exposure,
 
         with suppress_stdout():
             result2, _ = run_daophot(diff_image2, threshold,
-                                     star_tbl, niters=1, duet=duet)
+                                     star_tbl, niters=1, snr_lim=0., duet=duet)
         fl2_fit = result2['flux_fit'][0] * image_rate2.unit
         fl2_fite = result2['flux_unc'][0] * image_rate2.unit
 


### PR DESCRIPTION
Lowered the threshold in find from 5*RMS of sky to 2*RMS and implemented a S/N threshold in run_daophot. Default value is 5, can be set via snr_lim. find_daophot will only return sources with flux_fit / flux_unc >= snr_lim. 
Ap_phot does not have this detection limit set at the moment. This will increase the number of false positives from 'find', but the SNR threshold is much more robust than the 'peak' threshold.