### PR TITLE
Add COS background line estimates

### DIFF
--- a/astroduet/background.py
+++ b/astroduet/background.py
@@ -147,7 +147,7 @@ def airglow_lines(wave, airglow_level='Average'):
     """
     from astropy import units as u
 
-    levels = ['High', 'Average', 'Low']
+    levels = ['High', 'Average', 'Low', 'COS']
     assert airglow_level in levels
     flux_ind = levels.index(airglow_level) + 1 # +1 to offset from wavelength column
     

--- a/astroduet/data/airglow_lines.txt
+++ b/astroduet/data/airglow_lines.txt
@@ -1,6 +1,6 @@
 # fluxes in ph / s / cm2 / sr (need to divide by bin width to convert to density, assume delta functions)
 wave flux_low flux_ave flux_high
-1216 1.6e9       7.9e8       1.6e8
-1302 1.6e8       7.9e7       1.1e6
-1356 1.5e7       7.3e6       8.7e4
-2471 1.6e7       7.9e6       7.9e4
+1216 1.6e9       7.9e8       1.6e8      1.64e9
+1302 1.6e8       7.9e7       1.1e6      1.65e8
+1356 1.5e7       7.3e6       8.7e4      1.68e7
+2471 1.6e7       7.9e6       7.9e4      3.7e6

--- a/notebooks/Airglow Line Conversion.ipynb
+++ b/notebooks/Airglow Line Conversion.ipynb
@@ -1,0 +1,108 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from astropy import units as u"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from astropy.modeling.blackbody import FLAM"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/latex": [
+       "$\\mathrm{\\frac{erg}{\\mathring{A}\\,s\\,cm^{2}}}$"
+      ],
+      "text/plain": [
+       "Unit(\"erg / (Angstrom cm2 s)\")"
+      ]
+     },
+     "execution_count": 8,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "FLAM"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 9,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "ph_unit = u.ph / (u.cm**2 *u.s*u.AA)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 53,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "2471.0 Angstrom   3.70e+06 ph / (Angstrom cm2 s)\n",
+      "1356.0 Angstrom   1.68e+07 ph / (Angstrom cm2 s)\n",
+      "1302.0 Angstrom   1.65e+08 ph / (Angstrom cm2 s)\n",
+      "1216.0 Angstrom   1.64e+09 ph / (Angstrom cm2 s)\n"
+     ]
+    }
+   ],
+   "source": [
+    "scale = 1*u.sr / (u.arcsec*u.arcsec)\n",
+    "# From \n",
+    "for flux, line in zip([0.7e-15, 5.8e-15, 59e-15, 630e-15], [2471, 1356, 1302, 1216]):\n",
+    "    flux *= FLAM\n",
+    "    line *= u.AA\n",
+    "    ph_flux = flux.to(ph_unit, equivalencies=u.spectral_density(line))\n",
+    "    print('{} {:10.2e}'.format(line, ph_flux *scale.cgs.value))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python (duet)",
+   "language": "python",
+   "name": "duet"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.6.7"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}

--- a/notebooks/DUET Limiting Magnitudes STMC.ipynb
+++ b/notebooks/DUET Limiting Magnitudes STMC.ipynb
@@ -32,7 +32,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
+   "execution_count": 15,
    "metadata": {},
    "outputs": [
     {
@@ -42,9 +42,9 @@
       "\n",
       "\n",
       "B\n",
-      "Band1 300.0 s 5-σ magnitude limit: 21.230542480741885 mag(AB)\n",
-      "Band1 600.0 s 5-σ magnitude limit: 21.680542480741895 mag(AB)\n",
-      "Band1 900.0 s 5-σ magnitude limit: 21.880542480741898 mag(AB)\n"
+      "Band1 300.0 s 5-σ magnitude limit: 21.830542480741894 mag(AB)\n",
+      "Band1 600.0 s 5-σ magnitude limit: 22.280542480741904 mag(AB)\n",
+      "Band1 900.0 s 5-σ magnitude limit: 22.530542480741904 mag(AB)\n"
      ]
     }
    ],
@@ -68,7 +68,7 @@
     "print()\n",
     "for filter_type in ['B']:\n",
     "    print(filter_type)\n",
-    "    [bgd_band1, bgd_band2] = background_pixel_rate(duet, low_zodi=True, filter_type=filter_type)\n",
+    "    [bgd_band1, bgd_band2] = background_pixel_rate(duet, low_zodi=True, filter_type=filter_type, airglow_level='COS')\n",
     "    tot_bgd_rate = bgd_band1\n",
     "\n",
     "    for nframes in [1, 2, 3]:\n",

--- a/notebooks/DUET Limiting Magnitudes STMC.ipynb
+++ b/notebooks/DUET Limiting Magnitudes STMC.ipynb
@@ -2,18 +2,9 @@
  "cells": [
   {
    "cell_type": "code",
-   "execution_count": 17,
+   "execution_count": 1,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "The autoreload extension is already loaded. To reload it, use:\n",
-      "  %reload_ext autoreload\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "import astropy.units as u\n",
     "from astroduet.duet_telescope import load_telescope_parameters\n",
@@ -30,9 +21,6 @@
     "%load_ext autoreload\n",
     "%autoreload 2\n",
     "\n",
-    "\n",
-    "\n",
-    "\n",
     "from astropy.visualization import quantity_support\n",
     "import matplotlib\n",
     "font = {'family' : 'normal',\n",
@@ -44,61 +32,124 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 18,
+   "execution_count": 5,
    "metadata": {},
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "For 15e3 K source\n",
-      "Band 1 Photometric Zero Point (Swift UVW2): 20.300000000000033 mag(AB)\n",
-      "Band 1 Photometric Zero Point: 20.3305424807419 mag(AB)\n",
       "\n",
-      "Band 2 Photometric Zero Point (Swift UVW2): 20.70000000000004 mag(AB)\n",
-      "Band 2 Photometric Zero Point: 20.291224059720278 mag(AB)\n",
-      "\n"
+      "\n",
+      "B\n",
+      "Band1 300.0 s 5-σ magnitude limit: 21.230542480741885 mag(AB)\n",
+      "Band1 600.0 s 5-σ magnitude limit: 21.680542480741895 mag(AB)\n",
+      "Band1 900.0 s 5-σ magnitude limit: 21.880542480741898 mag(AB)\n"
      ]
     }
    ],
    "source": [
-    "# Band one\n",
+    "\n",
+    "# Band1\n",
+    "# 5-sigma limiting magnitude in 1, 2, 3, and 4 stacked frames.\n",
+    "\n",
+    "# Account for the fact that you're co-adding the two frames here:\n",
     "duet = config.Telescope()\n",
+    "duet.read_noise = duet.read_noise\n",
+    "\n",
+    "\n",
+    "#tot_bgd_rate = bgd_band1 + bgd_band2\n",
     "bandone = duet.bandpass1\n",
     "bandtwo = duet.bandpass2\n",
-    "print('For 15e3 K source')\n",
-    "swiftmag = 18 * u.ABmag\n",
-    "dmag = 0.1 * u.mag\n",
-    "band1_caught = False\n",
-    "band2_caught = False\n",
-    "while not (band1_caught & band2_caught):\n",
-    "    swiftmag += dmag\n",
-    "    band1_fluence, band2_fluence = bb_abmag_fluence(duet = duet, swiftmag=swiftmag, bbtemp=15e3*u.K)\n",
-    "    \n",
-    "    band1_rate = duet.fluence_to_rate(band1_fluence)\n",
-    "    band2_rate = duet.fluence_to_rate(band2_fluence)\n",
+    "exposure = 300*u.s\n",
+    "print()\n",
+    "siglimit=5\n",
+    "dmag = 0.05\n",
+    "print()\n",
+    "for filter_type in ['B']:\n",
+    "    print(filter_type)\n",
+    "    [bgd_band1, bgd_band2] = background_pixel_rate(duet, low_zodi=True, filter_type=filter_type)\n",
+    "    tot_bgd_rate = bgd_band1\n",
     "\n",
-    "    if band1_caught is False:\n",
-    "        if (band1_rate.value < 1.0):            \n",
-    "            bbmag1, foo = bb_abmag(swiftmag=swiftmag, bbtemp=15e3*u.K, bandone = bandone)\n",
-    "            print('Band 1 Photometric Zero Point (Swift UVW2): {}'.format(swiftmag))\n",
-    "            print('Band 1 Photometric Zero Point: {}'.format(bbmag1))\n",
-    "            print()\n",
-    "            band1_caught = True\n",
-    "        \n",
-    "    if band2_caught is False:\n",
-    "        if (band2_rate.value < 1.0):            \n",
-    "            foo, bbmag2 = bb_abmag(swiftmag=swiftmag, bbtemp=15e3*u.K, bandtwo = bandtwo)\n",
-    "            print('Band 2 Photometric Zero Point (Swift UVW2): {}'.format(swiftmag))\n",
-    "            print('Band 2 Photometric Zero Point: {}'.format(bbmag2))\n",
-    "            print()\n",
-    "            band2_caught = True\n",
+    "    for nframes in [1, 2, 3]:\n",
+    "        snr = 100\n",
+    "        swiftmag = 20 \n",
+    "        while snr > siglimit:\n",
+    "            swiftmag += dmag\n",
+    "            band1_fluence, band2_fluence = bb_abmag_fluence(duet =duet, swiftmag=swiftmag*u.ABmag, bbtemp=15e3*u.K, filter_type=filter_type)\n",
+    "            band1_rate = duet.fluence_to_rate(band1_fluence)\n",
+    "            band2_rate = duet.fluence_to_rate(band2_fluence)\n",
+    "            src_rate = band1_rate\n",
+    "\n",
+    "            snr = duet.calc_snr(exposure, src_rate, tot_bgd_rate, nint=nframes)\n",
+    "        bbmag1, bbmag2 = bb_abmag(swiftmag=swiftmag*u.ABmag, bbtemp=15e3*u.K, bandone = bandone, bandtwo=bandtwo)        \n",
+    "        print('Band1 {} {}-σ magnitude limit: {}'.format(nframes*exposure, siglimit, bbmag1))\n",
+    "\n",
     "\n"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 24,
+   "execution_count": 7,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\n",
+      "\n",
+      "B\n",
+      "Band2 300.0 s 5-σ magnitude limit: 20.84122405972026 mag(AB)\n",
+      "Band2 600.0 s 5-σ magnitude limit: 21.241224059720267 mag(AB)\n",
+      "Band2 900.0 s 5-σ magnitude limit: 21.491224059720267 mag(AB)\n"
+     ]
+    }
+   ],
+   "source": [
+    "\n",
+    "# Band2\n",
+    "# 5-sigma limiting magnitude in 1, 2, 3, and 4 stacked frames.\n",
+    "\n",
+    "# Account for the fact that you're co-adding the two frames here:\n",
+    "duet = config.Telescope()\n",
+    "duet.read_noise = duet.read_noise\n",
+    "\n",
+    "\n",
+    "#tot_bgd_rate = bgd_band1 + bgd_band2\n",
+    "bandone = duet.bandpass1\n",
+    "bandtwo = duet.bandpass2\n",
+    "exposure = 300*u.s\n",
+    "print()\n",
+    "siglimit=5\n",
+    "dmag = 0.05\n",
+    "print()\n",
+    "for filter_type in ['B']:\n",
+    "    print(filter_type)\n",
+    "    [bgd_band1, bgd_band2] = background_pixel_rate(duet, low_zodi=True, filter_type=filter_type)\n",
+    "    tot_bgd_rate = bgd_band2\n",
+    "\n",
+    "    for nframes in [1, 2, 3]:\n",
+    "        snr = 100\n",
+    "        swiftmag = 20 \n",
+    "        while snr > siglimit:\n",
+    "            swiftmag += dmag\n",
+    "            band1_fluence, band2_fluence = bb_abmag_fluence(duet =duet, swiftmag=swiftmag*u.ABmag, bbtemp=15e3*u.K, filter_type=filter_type)\n",
+    "            band1_rate = duet.fluence_to_rate(band1_fluence)\n",
+    "            band2_rate = duet.fluence_to_rate(band2_fluence)\n",
+    "            src_rate = band2_rate\n",
+    "\n",
+    "            snr = duet.calc_snr(exposure, src_rate, tot_bgd_rate, nint=nframes)\n",
+    "        bbmag1, bbmag2 = bb_abmag(swiftmag=swiftmag*u.ABmag, bbtemp=15e3*u.K, bandone = bandone, bandtwo=bandtwo)        \n",
+    "        print('Band2 {} {}-σ magnitude limit: {}'.format(nframes*exposure, siglimit, bbmag2))\n",
+    "\n",
+    "\n",
+    "\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
    "metadata": {},
    "outputs": [
     {
@@ -138,166 +189,6 @@
     "    tot_bgd_rate = bgd_band1 + bgd_band2\n",
     "\n",
     "    for nframes in [1, 2, 3]:\n",
-    "        snr = 100\n",
-    "        swiftmag = 20 \n",
-    "        while snr > siglimit:\n",
-    "            swiftmag += dmag\n",
-    "            band1_fluence, band2_fluence = bb_abmag_fluence(duet =duet, swiftmag=swiftmag*u.ABmag, bbtemp=15e3*u.K, filter_type=filter_type)\n",
-    "            band1_rate = duet.fluence_to_rate(band1_fluence)\n",
-    "            band2_rate = duet.fluence_to_rate(band2_fluence)\n",
-    "            src_rate = band1_rate + band2_rate\n",
-    "\n",
-    "            snr = duet.calc_snr(exposure, src_rate, tot_bgd_rate, nint=nframes)\n",
-    "        bbmag1, bbmag2 = bb_abmag(swiftmag=swiftmag*u.ABmag, bbtemp=15e3*u.K, bandone = bandone, bandtwo=bandtwo)        \n",
-    "        print('Stacked Bands {} {}-σ magnitude limit: {}'.format(nframes*exposure, siglimit, bbmag1))\n",
-    "\n",
-    "\n"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 22,
-   "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "\n",
-      "\n",
-      "B\n",
-      "DUET1 300.0 s 5-σ magnitude limit: 21.230542480741885 mag(AB)\n",
-      "DUET1 600.0 s 5-σ magnitude limit: 21.680542480741895 mag(AB)\n",
-      "DUET1 900.0 s 5-σ magnitude limit: 21.880542480741898 mag(AB)\n"
-     ]
-    }
-   ],
-   "source": [
-    "\n",
-    "# DUET1\n",
-    "# 5-sigma limiting magnitude in 1, 2, 3, and 4 stacked frames.\n",
-    "\n",
-    "duet = config.Telescope()\n",
-    "\n",
-    "\n",
-    "#tot_bgd_rate = bgd_band1 + bgd_band2\n",
-    "bandone = duet.bandpass1\n",
-    "bandtwo = duet.bandpass2\n",
-    "exposure = 300*u.s\n",
-    "print()\n",
-    "siglimit=5\n",
-    "dmag = 0.05\n",
-    "print()\n",
-    "for filter_type in ['B']:\n",
-    "    print(filter_type)\n",
-    "    [bgd_band1, bgd_band2] = background_pixel_rate(duet, low_zodi=True, filter_type=filter_type)\n",
-    "    tot_bgd_rate = bgd_band1\n",
-    "\n",
-    "    for nframes in [1, 2, 3]:\n",
-    "        snr = 100\n",
-    "        swiftmag = 20 \n",
-    "        while snr > siglimit:\n",
-    "            swiftmag += dmag\n",
-    "            band1_fluence, band2_fluence = bb_abmag_fluence(duet =duet, swiftmag=swiftmag*u.ABmag, bbtemp=15e3*u.K, filter_type=filter_type)\n",
-    "            band1_rate = duet.fluence_to_rate(band1_fluence)\n",
-    "            band2_rate = duet.fluence_to_rate(band2_fluence)\n",
-    "            src_rate = band1_rate \n",
-    "\n",
-    "            snr = duet.calc_snr(exposure, src_rate, tot_bgd_rate, nint=nframes)\n",
-    "        bbmag1, bbmag2 = bb_abmag(swiftmag=swiftmag*u.ABmag, bbtemp=15e3*u.K, bandone = bandone, bandtwo=bandtwo)        \n",
-    "        print('DUET1 {} {}-σ magnitude limit: {}'.format(nframes*exposure, siglimit, bbmag1))\n",
-    "\n",
-    "\n",
-    "\n"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 23,
-   "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "\n",
-      "\n",
-      "B\n",
-      "DUET1 300.0 s 5-σ magnitude limit: 21.28054248074189 mag(AB)\n",
-      "DUET1 600.0 s 5-σ magnitude limit: 21.680542480741895 mag(AB)\n",
-      "DUET1 900.0 s 5-σ magnitude limit: 21.930542480741895 mag(AB)\n"
-     ]
-    }
-   ],
-   "source": [
-    "\n",
-    "# DUET1\n",
-    "# 5-sigma limiting magnitude in 1, 2, 3, and 4 stacked frames.\n",
-    "\n",
-    "duet = config.Telescope()\n",
-    "\n",
-    "\n",
-    "#tot_bgd_rate = bgd_band1 + bgd_band2\n",
-    "bandone = duet.bandpass1\n",
-    "bandtwo = duet.bandpass2\n",
-    "exposure = 300*u.s\n",
-    "print()\n",
-    "siglimit=5\n",
-    "dmag = 0.05\n",
-    "print()\n",
-    "for filter_type in ['B']:\n",
-    "    print(filter_type)\n",
-    "    [bgd_band1, bgd_band2] = background_pixel_rate(duet, low_zodi=True, filter_type=filter_type)\n",
-    "    tot_bgd_rate = bgd_band2\n",
-    "\n",
-    "    for nframes in [1, 2, 3]:\n",
-    "        snr = 100\n",
-    "        swiftmag = 20 \n",
-    "        while snr > siglimit:\n",
-    "            swiftmag += dmag\n",
-    "            band1_fluence, band2_fluence = bb_abmag_fluence(duet =duet, swiftmag=swiftmag*u.ABmag, bbtemp=15e3*u.K, filter_type=filter_type)\n",
-    "            band1_rate = duet.fluence_to_rate(band1_fluence)\n",
-    "            band2_rate = duet.fluence_to_rate(band2_fluence)\n",
-    "            src_rate = band2_rate \n",
-    "\n",
-    "            snr = duet.calc_snr(exposure, src_rate, tot_bgd_rate, nint=nframes)\n",
-    "        bbmag1, bbmag2 = bb_abmag(swiftmag=swiftmag*u.ABmag, bbtemp=15e3*u.K, bandone = bandone, bandtwo=bandtwo)        \n",
-    "        print('DUET1 {} {}-σ magnitude limit: {}'.format(nframes*exposure, siglimit, bbmag1))\n",
-    "\n",
-    "\n",
-    "\n",
-    "\n"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "\n",
-    "# Stacked channels\n",
-    "# 5-sigma limiting magnitude in 1, 2, 3, and 4 stacked frames.\n",
-    "\n",
-    "# Account for the fact that you're co-adding the two frames here:\n",
-    "duet = config.Telescope()\n",
-    "duet.read_noise = (2**0.5) * duet.read_noise\n",
-    "\n",
-    "\n",
-    "#tot_bgd_rate = bgd_band1 + bgd_band2\n",
-    "bandone = duet.bandpass1\n",
-    "bandtwo = duet.bandpass2\n",
-    "exposure = 300*u.s\n",
-    "print()\n",
-    "siglimit=5\n",
-    "dmag = 0.05\n",
-    "print()\n",
-    "for filter_type in ['C', 'B', 'A']:\n",
-    "    print(filter_type)\n",
-    "    [bgd_band1, bgd_band2] = background_pixel_rate(duet, high_zodi=True, filter_type=filter_type)\n",
-    "    tot_bgd_rate = bgd_band1 + bgd_band2\n",
-    "\n",
-    "    for nframes in [3]:\n",
     "        snr = 100\n",
     "        swiftmag = 20 \n",
     "        while snr > siglimit:\n",
@@ -538,13 +429,23 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 11,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Low-Zodi 10-sig, 1110.4181967543602 seconds\n",
+      "High-Zodi 10-sig, 1824.2163162763466 seconds\n",
+      "High-Zodi 5-sig, 526.2848228170415 seconds\n"
+     ]
+    }
+   ],
    "source": [
     "# FOM: Time to 22 ABmag for this configuration for DUET1\n",
     "# Old FOM for this \n",
-    "duet = config.Telescope(config='reduced_baseline')\n",
+    "duet = config.Telescope(config='minimum_mass')\n",
     "duet.read_noise = 3\n",
     "\n",
     "\n",
@@ -552,7 +453,7 @@
     "bandtwo = duet.bandpass2\n",
     "\n",
     "siglimit=10\n",
-    "swiftmag = 21\n",
+    "swiftmag = 20\n",
     "dmag = 0.05\n",
     "bbmag1 = 5*u.ABmag\n",
     "bbmag_target = 22*u.ABmag\n",
@@ -587,146 +488,6 @@
     "print('High-Zodi {}-sig, {} seconds'.format(siglimit, req_exp.value))\n",
     "\n",
     "\n"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 8,
-   "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "{'eff_wave': <Quantity 280.56077333 nm>,\n",
-       " 'eff_width': <Quantity 51.25641246 nm>}"
-      ]
-     },
-     "execution_count": 8,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
-   "source": [
-    "duet.band2\n"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 9,
-   "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/latex": [
-       "$[254.93257,~306.18898] \\; \\mathrm{nm}$"
-      ],
-      "text/plain": [
-       "<Quantity [254.9325671 , 306.18897956] nm>"
-      ]
-     },
-     "execution_count": 9,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
-   "source": [
-    "duet.bandpass2"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 10,
-   "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/latex": [
-       "$[183.13463,~214.14254] \\; \\mathrm{nm}$"
-      ],
-      "text/plain": [
-       "<Quantity [183.13463401, 214.1425365 ] nm>"
-      ]
-     },
-     "execution_count": 10,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
-   "source": [
-    "duet.bandpass1"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 12,
-   "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "{'eff_wave': <Quantity 280.56077333 nm>,\n",
-       " 'eff_width': <Quantity 51.25641246 nm>}"
-      ]
-     },
-     "execution_count": 12,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
-   "source": [
-    "duet.band2"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 14,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "duet.pixel = 6.55*u.arcsec\n"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 15,
-   "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/latex": [
-       "$6.55 \\; \\mathrm{{}^{\\prime\\prime}}$"
-      ],
-      "text/plain": [
-       "<Quantity 6.55 arcsec>"
-      ]
-     },
-     "execution_count": 15,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
-   "source": [
-    "duet.pixel"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 16,
-   "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "0.9643416672473358"
-      ]
-     },
-     "execution_count": 16,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
-   "source": [
-    "(6.55/6.67)**2"
    ]
   },
   {

--- a/notebooks/SN Rates.ipynb
+++ b/notebooks/SN Rates.ipynb
@@ -1,0 +1,118 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "from astropy import units as u\n",
+    "from numpy import pi"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 27,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "fov = (56 * u.deg * u.deg).to(u.sr).value\n",
+    "frac_sky = fov / (4*pi)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 28,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": [
+    "rate = 0.447e-04 # per Mpc / year"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 29,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "54.90131941512641"
+      ]
+     },
+     "execution_count": 29,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "dist = 600\n",
+    "vol = (4/3)*pi*(dist)**3\n",
+    "vol*frac_sky*rate"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 42,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "630.9573444801929\n"
+     ]
+    },
+    {
+     "data": {
+      "text/plain": [
+       "63.84531449575429"
+      ]
+     },
+     "execution_count": 42,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "abs_mag = -17\n",
+    "limit = 22\n",
+    "dist = 10**((limit - abs_mag)/5) * 10/1e6\n",
+    "print(dist)\n",
+    "vol = (4/3)*pi*(dist)**3\n",
+    "vol*frac_sky*rate"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python (duet)",
+   "language": "python",
+   "name": "duet"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.6.7"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}

--- a/notebooks/Saturation Test.ipynb
+++ b/notebooks/Saturation Test.ipynb
@@ -2,7 +2,7 @@
  "cells": [
   {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": 5,
    "metadata": {
     "collapsed": true
    },
@@ -15,7 +15,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
+   "execution_count": 6,
    "metadata": {
     "collapsed": true
    },
@@ -26,7 +26,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": 7,
    "metadata": {
     "collapsed": false
    },
@@ -35,7 +35,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "17.40000000000005 17824.063002088533 ph\n"
+      "15.800000000000026 17737.013937689546 ph\n"
      ]
     }
    ],
@@ -44,7 +44,7 @@
     "\n",
     "\n",
     "for abmag in np.arange(14, 18, 0.05):\n",
-    "    counts = exposure * duet.fluence_to_rate(utils.duet_abmag_to_fluence(abmag*u.ABmag, band = duet.bandpass1))\n",
+    "    counts = exposure * duet.fluence_to_rate(utils.duet_abmag_to_fluence(abmag*u.ABmag, 1))\n",
     "    \n",
     "    if counts.value < 18e3:\n",
     "        print(abmag, counts)\n",
@@ -53,7 +53,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 24,
+   "execution_count": 9,
    "metadata": {
     "collapsed": false
    },
@@ -62,16 +62,16 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "16.346000000000007 17296.520402368573 ph\n"
+      "13.876000000000012 17391.188281812414 ph\n"
      ]
     }
    ],
    "source": [
-    "exposure = 120*u.s\n",
+    "exposure = 50*u.s\n",
     "\n",
     "\n",
-    "for abmag in np.arange(14, 18, 0.051):\n",
-    "    counts = exposure * duet.fluence_to_rate(utils.duet_abmag_to_fluence(abmag*u.ABmag, band = duet.bandpass2))\n",
+    "for abmag in np.arange(10, 18, 0.1):\n",
+    "    counts = exposure * duet.fluence_to_rate(utils.duet_abmag_to_fluence(abmag*u.ABmag, 1))\n",
     "    if counts.value < 18e3:\n",
     "        print(abmag, counts)\n",
     "        break"
@@ -89,6 +89,32 @@
     "    \n",
     "    dist = ((10 * 10**((sat_mag - abs_mag) / 5))*u.pc).to(u.Mpc)\n",
     "    return dist"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 14,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/latex": [
+       "$12.5 \\; \\mathrm{{}^{\\prime\\prime}}$"
+      ],
+      "text/plain": [
+       "<Quantity 12.5 arcsec>"
+      ]
+     },
+     "execution_count": 14,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "np.sqrt(duet.psf_fwhm**2 - 2.5*(u.arcsec**2))\n",
+    "\n"
    ]
   },
   {
@@ -115,9 +141,66 @@
    "source": [
     "saturation_distance(abs_mag = -18, sat_mag=17.5)"
    ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 32,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "17.130998289964314\n"
+     ]
+    }
+   ],
+   "source": [
+    "pixel = 0.655 \n",
+    "rms = pixel * 6.35\n",
+    "pointing = 5.0\n",
+    "rms = np.sqrt(pointing**2 + rms**2)\n",
+    "fwhm = 2.634 * rms\n",
+    "print(fwhm)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 26,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "13.907208269091571\n"
+     ]
+    }
+   ],
+   "source": [
+    "pixel = 0.655 \n",
+    "rms = pixel * 7.1\n",
+    "rms = np.sqrt(2.5**2 + rms**2)\n",
+    "fwhm = 2.634 * rms\n",
+    "print(fwhm)\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": []
   }
  ],
  "metadata": {
+  "anaconda-cloud": {},
   "kernelspec": {
    "display_name": "Python (duet)",
    "language": "python",


### PR DESCRIPTION
...and updates to background.py to handle this.

Also update some notebooks computing the expected limiting magnitudes.

I think we're 100% read noise dominated in the low_zodi case.