### PR TITLE
Edited panstarrs_to_duet to enable parallelization

### DIFF
--- a/astroduet/utils.py
+++ b/astroduet/utils.py
@@ -586,13 +586,13 @@ def panstarrs_to_duet(panmags, duet=None):
     
     # Loop over stars:
     for i, star in enumerate(panmags):
-        # Replace bad values with nan:
-        star[star==-999.] = np.nan
-        # Order and convert to magnitudes
-        mags = star[::2]*u.ABmag
+        # Extract magnitudes values
+        mags = star[::2]
+        # Find valid values
+        valid = ~(mags==-999)
+        # Convert to magnitudes
+        mags = mags*u.ABmag
         magerrs = star[1::2]
-        # Find valid values:
-        valid = ~(np.isnan(mags))
         
         # Convert to flux densities
         fden = mags[valid].to(FLAM,equivalencies=u.spectral_density(pswav[valid]))


### PR DESCRIPTION
I just made some small edits to the PanSTARRS_to_duet function so that it no longer does in-place array manipulation. That way one can easily write a wrapper in order to split the job into multiple threads.